### PR TITLE
hotfix schema for tool calls

### DIFF
--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -247,10 +247,7 @@ class MLXLMHandler:
             # Reformat messages
             refined_messages = []
             for message in messages:
-                refined_messages.append({
-                    "role": message["role"],
-                    "content": message["content"]
-                })
+                refined_messages.append({k: v for k, v in message.items() if v is not None})
 
             # Call the model
             response = self.model(

--- a/app/schemas/openai.py
+++ b/app/schemas/openai.py
@@ -65,21 +65,22 @@ class ChatCompletionMessageToolCall(BaseModel):
     """
     Represents a tool call in a message.
     """
-    id: str = Field(..., description="The ID of the tool call.")
+    id: Optional[str] = Field(None, description="The ID of the tool call.")
     function: FunctionCall = Field(..., description="The function call details.")
     type: Literal["function"] = Field(..., description="The type of tool call, always 'function'.")
-    index: int = Field(..., description="The index of the tool call.")
+    index: Optional[int] = Field(None, description="The index of the tool call.")
 
 class Message(BaseModel):
     """
     Represents a message in a chat completion.
     """
-    content: Union[str, List[MultimodalContentItem]] = Field(None, description="The content of the message, either text or a list of content items (vision, audio, or multimodal).")
+    content: Union[str, List[MultimodalContentItem], None] = Field(None, description="The content of the message, either text or a list of content items (vision, audio, or multimodal).")
     refusal: Optional[str] = Field(None, description="The refusal reason, if any.")
     role: Literal["system", "user", "assistant", "tool"] = Field(..., description="The role of the message sender.")
     function_call: Optional[FunctionCall] = Field(None, description="The function call, if any.")
     reasoning_content: Optional[str] = Field(None, description="The reasoning content, if any.")
     tool_calls: Optional[List[ChatCompletionMessageToolCall]] = Field(None, description="List of tool calls, if any.")
+    tool_call_id: Optional[str] = Field(None, description="The ID of the tool call, if any.")
 
 # Common request base for both streaming and non-streaming
 class ChatCompletionRequestBase(BaseModel):


### PR DESCRIPTION
## Fix Tool Calls Schema Compatibility

**Summary**: Fixes schema compatibility issues for tool calls by making fields optional and improving message processing.

### Changes
- **Schema**: Made `id`/`index` optional in `ChatCompletionMessageToolCall`, added `tool_call_id` field
- **Handler**: Enhanced message filtering to preserve all non-null fields

### Files
- `app/schemas/openai.py` - Schema updates
- `app/handler/mlx_lm.py` - Message processing improvements

**Type**: Bug Fix | **Breaking**: No