### PR TITLE
sync `mflux` to version 0.9.6

### DIFF
--- a/app/models/mflux.py
+++ b/app/models/mflux.py
@@ -1,5 +1,5 @@
 from PIL import Image
-from mflux import Flux1, Config
+from mflux.flux.flux import Flux1, Config
 
 class MLXFlux:
     """Base class for Flux models with common functionality."""

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "mlx-vlm==0.3.2",
         "mlx-lm==0.26.3",
         "mlx-embeddings==0.0.3",
-        "mflux==0.9.3",
+        "mflux==0.9.6",
         "fastapi==0.115.14",
         "uvicorn==0.35.0",
         "Pillow==10.4.0",


### PR DESCRIPTION
# Sync mflux to version 0.9.6

Updates mflux dependency to version 0.9.6 and fixes import path to use the new module structure (`mflux.flux.flux`).

## Changes
- Update mflux from 0.9.3 → 0.9.6 in `setup.py`
- Fix import path in `app/models/mflux.py` to use `mflux.flux.flux`

This ensures compatibility with the latest mflux release and resolves any import issues caused by the module restructuring.