### PR TITLE
health check should be a `get` method

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -23,16 +23,12 @@ from app.utils.errors import create_error_response
 router = APIRouter()
 
 
-@router.post("/health")
-async def health(raw_request: Request):
+@router.get("/health")
+async def health():
     """
     Health check endpoint.
     """
-    try:
-        return {"status": "ok"}
-    except Exception as e:
-        logger.error(f"Health check failed: {str(e)}")
-        return JSONResponse(content=create_error_response("Health check failed", "server_error", 500), status_code=500)
+    return {"status": "ok"}
 
 @router.get("/v1/queue/stats")
 async def queue_stats(raw_request: Request):


### PR DESCRIPTION
# fix: Change health check endpoint from POST to GET method

The health check endpoint at `/health` has been updated to use the correct HTTP method. Health checks should be GET requests as they are read-only operations that don't modify server state. This change improves API consistency and follows REST conventions.

## Changes
- Changed `@router.post("/health")` to `@router.get("/health")`
- Simplified the endpoint by removing unnecessary error handling and request parameter
- Health check now returns a simple `{"status": "ok"}` response

This fix ensures the health check endpoint follows standard HTTP conventions and can be easily accessed via simple GET requests.