### PR TITLE
Fix/function callings

### DIFF
--- a/app/handler/parser/harmony.py
+++ b/app/handler/parser/harmony.py
@@ -41,7 +41,7 @@ class HarmonyParser:
                     }
                 self.tool_state = True
                 return self.end_stream, {
-                    "name": stream_text.current_recipient.replace("function.", ""),
+                    "name": stream_text.current_recipient.replace("functions.", ""),
                     "arguments": ""
                 }
             return self.end_stream, content

--- a/app/handler/parser/harmony.py
+++ b/app/handler/parser/harmony.py
@@ -37,7 +37,7 @@ class HarmonyParser:
                 if self.tool_state:
                     return self.end_stream, {
                         "name": None,
-                        "arguments": content.replace("functions.", "")
+                        "arguments": content
                     }
                 self.tool_state = True
                 return self.end_stream, {


### PR DESCRIPTION
# Fix function calling parsing in Harmony parser

Fixes two issues in `app/handler/parser/harmony.py`:

- **Fix recipient name parsing**: Change `function.` to `functions.` when extracting the tool name from `stream_text.current_recipient`
- **Remove unnecessary string replacement**: Remove the `.replace("functions.", "")` call on the `arguments` content to preserve the original function arguments

These changes ensure proper parsing of function calling responses from the Harmony model, maintaining the correct function names and argument structure.