### PR TITLE
it should be `functions.` instead of `function.`

### DIFF
--- a/app/handler/parser/harmony.py
+++ b/app/handler/parser/harmony.py
@@ -62,7 +62,7 @@ class HarmonyParser:
                 res["reasoning_content"] = message.content[0].text
             elif message.channel == "commentary":
                 res["tool_calls"] = [{
-                    "name": message.recipient.replace("function.", ""),
+                    "name": message.recipient.replace("functions.", ""),
                     "arguments": message.content[0].text
                 }]
             elif message.channel == "final":


### PR DESCRIPTION
# Fix GPT-OSS function calling prefix

**Fix:** Correct function name extraction in Harmony parser for GPT-OSS models

**Changes:**
- Update `message.recipient.replace()` from `"function."` to `"functions."` in `harmony.py`
- Ensures proper function name parsing when GPT-OSS models return function calls