### PR TITLE
fix(harmony): fix function argument initialization in parser

### DIFF
--- a/app/handler/parser/harmony.py
+++ b/app/handler/parser/harmony.py
@@ -123,8 +123,8 @@ class HarmonyParser:
                             if hasattr(stream_text, 'current_recipient') and stream_text.current_recipient:
                                 function_name = stream_text.current_recipient.replace("functions.", "")
                                 self._current_function_name = function_name
-                            function_arguments = [""]  # Initialize with empty string
-                            self._function_arguments = [""]
+                            function_arguments = [content]
+                            self._function_arguments = [content]
                             
                     elif current_channel == ChannelType.FINAL.value:
                         contents.append(content)

--- a/app/version.py
+++ b/app/version.py
@@ -3,4 +3,4 @@
 # Minor: Minor version number (increments when new features are added)
 # Patch: Patch version number (increments when bug fixes are made)
 
-__version__ = "1.2.14"   
+__version__ = "1.2.15"   


### PR DESCRIPTION
# Fix Harmony Parser Function Argument Initialization

## Summary
Fixes a bug where function arguments were initialized with empty strings instead of actual content, causing loss of initial argument data.

## Changes
- **File:** `app/handler/parser/harmony.py` (lines 123-126)
- **Fix:** Initialize `function_arguments` and `_function_arguments` with `[content]` instead of `[""]`

## Impact
Resolves incomplete function calls by ensuring all argument content is captured from the beginning.