### PR TITLE
feat: add guidance_scale and improve image generation defaults

### DIFF
--- a/app/handler/mflux.py
+++ b/app/handler/mflux.py
@@ -117,6 +117,7 @@ class MLXFluxHandler:
                 "negative_prompt": request.negative_prompt,
                 "steps": request.steps,
                 "seed": request.seed,
+                "guidance": request.guidance_scale,
                 "width": width,
                 "height": height
             }

--- a/app/schemas/openai.py
+++ b/app/schemas/openai.py
@@ -17,6 +17,7 @@ class Config:
     MULTIMODAL_MODEL = "local-multimodal-model"  # Model used for multimodal requests
     EMBEDDING_MODEL = "local-embedding-model"  # Model used for generating embeddings
     IMAGE_GENERATION_MODEL = "local-image-generation-model"
+    IMAGE_EDIT_MODEL = "local-image-edit-model"
 
 class ErrorResponse(BaseModel):
     object: str = Field("error", description="The object type, always 'error'.")
@@ -318,7 +319,8 @@ class ImageGenerationRequest(BaseModel):
     negative_prompt: Optional[str] = Field(None, description="A text description of the desired image(s). The maximum length is 1000 characters.", max_length=1000)
     model: Optional[str] = Field(default=Config.IMAGE_GENERATION_MODEL, description="The model to use for image generation")
     size: Optional[ImageSize] = Field(default=ImageSize.LARGE, description="The size of the generated images")
-    steps: Optional[int] = Field(default=4, ge=1, le=50, description="The number of inference steps (1-50)")
+    guidance_scale: Optional[float] = Field(default=4.5, description="The guidance scale for the image generation")
+    steps: Optional[int] = Field(default=28, ge=1, le=50, description="The number of inference steps (1-50)")
     seed: Optional[int] = Field(42, description="Seed for reproducible generation")
     response_format: Optional[ResponseFormat] = Field(default=ResponseFormat.B64_JSON, description="The format in which the generated images are returned")
 
@@ -346,13 +348,14 @@ class ImageGenerationErrorResponse(BaseModel):
 class ImageEditRequest:
     """Request data for OpenAI-compatible image edit API"""
     def __init__(self, image: UploadFile, prompt: str, model: Optional[str] = None,
-                 negative_prompt: Optional[str] = None, guidance_scale: Optional[float] = 2.5,
-                 response_format: Optional[ResponseFormat] = ResponseFormat.B64_JSON,
-                 seed: Optional[int] = 42, size: Optional[ImageSize] = None,
-                 steps: Optional[int] = 4):
+                negative_prompt: Optional[str] = None, guidance_scale: Optional[float] = 2.5,
+                response_format: Optional[ResponseFormat] = ResponseFormat.B64_JSON,
+                seed: Optional[int] = 42, size: Optional[ImageSize] = None,
+                steps: Optional[int] = 28):
+       
         self.image = image
         self.prompt = prompt
-        self.model = model or Config.IMAGE_GENERATION_MODEL
+        self.model = model or Config.IMAGE_EDIT_MODEL
         self.negative_prompt = negative_prompt
         self.guidance_scale = guidance_scale
         self.response_format = response_format


### PR DESCRIPTION
# Enhance Image Generation Schema and Defaults

## 🎯 Summary
This PR enhances the image generation and editing capabilities by improving schema defaults and adding support for guidance scale parameter, resulting in better image quality and more configurable generation options.

## ✨ Key Changes

### 🔧 Schema Enhancements
- **Added `guidance_scale` parameter** to `ImageGenerationRequest` with a default value of `4.5`
- **Improved default steps** from 4 to 28 for significantly better image quality
- **Added dedicated `IMAGE_EDIT_MODEL` configuration** for better separation of concerns