### PR TITLE
docs: Phase 0 Engine Warm-Up - complete architecture mapping

### DIFF
--- a/docs/FUSION_PHASE0.md
+++ b/docs/FUSION_PHASE0.md
@@ -1,0 +1,356 @@
+# FUSION_PHASE0 – Engine Warm-Up
+
+**Repo**: `mlx-openai-server-lab`
+**Role**: Tier 3 Compute Fabric / Stateless MLX Inference Engine
+**Date**: 2025-11-16
+
+---
+
+## 1. Executive Summary
+
+This repository implements a **stateless, OpenAI-compatible HTTP server** that exposes MLX-based models (text, multimodal, embeddings, audio, image generation) on Apple Silicon. It is designed to be a drop-in replacement for OpenAI API endpoints running entirely locally.
+
+**Key Architecture:**
+- FastAPI-based HTTP server with uvicorn
+- Asynchronous request queue with semaphore-based concurrency control
+- Model handlers wrapping MLX libraries (mlx-lm, mlx-vlm, mlx-whisper, mlx-embeddings, mflux)
+- Streaming and non-streaming inference support
+- Zero persistent state (all stateless)
+
+**Current Limitations:**
+- Single model per server instance (model loaded at startup, not hot-swappable)
+- No model registry or multi-model management
+- No persistent queue or job tracking
+- No database or state storage
+- Concurrency defaults to 1 (sequential processing)
+
+---
+
+## 2. High-Level Code Map
+
+### Entrypoints
+| Path | Function | Description |
+|------|----------|-------------|
+| `app/cli.py:74` | `cli()` | Click CLI group, main entry point |
+| `app/cli.py:145` | `launch()` | CLI command that starts the server |
+| `app/main.py:50` | `parse_args()` | Alternative argparse-based CLI parser |
+| `app/main.py:189` | `setup_server()` | Creates FastAPI app and uvicorn config |
+| `app/main.py:82` | `create_lifespan()` | Factory for FastAPI lifespan context manager |
+| `pyproject.toml:56` | Script entry | `mlx-openai-server` console script → `app.cli:cli` |
+
+### Model Loading & Registry
+| Path | Class/Function | Description |
+|------|----------------|-------------|
+| `app/models/mlx_lm.py:23` | `MLX_LM.__init__()` | Loads language model via `mlx_lm.utils.load()` |
+| `app/models/mlx_lm.py:136` | `MLX_LM.__call__()` | Inference entry point (streaming/non-streaming) |
+| `app/models/mlx_vlm.py` | `MLX_VLM` | Multimodal model wrapper (mlx-vlm) |
+| `app/models/mlx_embeddings.py` | `MLXEmbeddings` | Embeddings model wrapper |
+| `app/models/mlx_whisper.py` | `MLXWhisper` | Audio transcription model wrapper |
+| `app/models/mflux.py` | `MFlux` | Flux image generation model wrapper |
+| `app/handler/mlx_lm.py:16` | `MLXLMHandler` | Handler that wraps MLX_LM with queue |
+| `app/handler/mlx_vlm.py` | `MLXVLMHandler` | Handler for multimodal models |
+| `app/handler/mlx_embeddings.py` | `MLXEmbeddingsHandler` | Handler for embeddings |
+| `app/handler/mlx_whisper.py` | `MLXWhisperHandler` | Handler for Whisper |
+| `app/handler/mflux.py` | `MLXFluxHandler` | Handler for Flux image generation |
+| `app/main.py:88-149` | Lifespan handler selection | Model type → Handler instantiation |
+
+**Model Selection Logic:**
+- Model type specified via `--model-type` CLI arg (choices: lm, multimodal, image-generation, image-edit, embeddings, whisper)
+- Appropriate handler instantiated in `create_lifespan()` based on model type
+- Model loaded synchronously at server startup
+- **No runtime model switching** – one model per server instance
+
+### Configuration & Environment
+| Path | Config Method | Description |
+|------|---------------|-------------|
+| `app/cli.py:146-258` | Click options | All server config via CLI flags |
+| `app/main.py:51-75` | Argparse | Alternative CLI arg parsing |
+| `app/models/mlx_lm.py:15-21` | Environment variables | Default sampling params (TEMPERATURE, TOP_P, etc.) |
+| `app/cli.py:11` | `Config` class | Configuration container for server parameters |
+
+**Key Config Parameters:**
+- `--model-path`: Path to model directory or HuggingFace identifier
+- `--model-type`: Model type (lm, multimodal, embeddings, etc.)
+- `--context-length`: Max context length (default: 32768)
+- `--port`: Server port (default: 8000)
+- `--host`: Server host (default: 0.0.0.0)
+- `--max-concurrency`: Max concurrent requests (default: 1)
+- `--queue-timeout`: Request timeout in seconds (default: 300)
+- `--queue-size`: Max pending requests (default: 100)
+
+**No config files** – all configuration via CLI arguments.
+
+### HTTP Routing & API
+| Path | Route | Handler |
+|------|-------|---------|
+| `app/api/endpoints.py:34` | `GET /health` | Health check (no dependencies) |
+| `app/api/endpoints.py:41` | `GET /v1/models` | List available models |
+| `app/api/endpoints.py:58` | `GET /v1/queue/stats` | Queue statistics |
+| `app/api/endpoints.py:82` | `POST /v1/chat/completions` | Chat completions (streaming/non-streaming) |
+| `app/api/endpoints.py:102` | `POST /v1/embeddings` | Generate embeddings |
+| `app/api/endpoints.py:116` | `POST /v1/images/generations` | Generate images (Flux) |
+| `app/api/endpoints.py:141` | `POST /v1/images/edits` | Edit images (Flux kontext) |
+| `app/api/endpoints.py:166` | `POST /v1/audio/transcriptions` | Transcribe audio (Whisper) |
+| `app/main.py:207` | Router inclusion | `app.include_router(router)` |
+
+**Request Flow:**
+1. FastAPI receives HTTP request
+2. Request validated against Pydantic schemas (`app/schemas/openai.py`)
+3. Handler retrieved from `app.state.handler`
+4. Request enqueued in handler's RequestQueue
+5. Worker processes request when semaphore available
+6. Response streamed or returned as JSON
+
+### Queue & Concurrency
+| Path | Class/Function | Description |
+|------|----------------|-------------|
+| `app/core/queue.py:33` | `RequestQueue` | Async queue with semaphore concurrency control |
+| `app/core/queue.py:49` | `semaphore` | `asyncio.Semaphore(max_concurrency)` |
+| `app/core/queue.py:50` | `queue` | `asyncio.Queue(maxsize=queue_size)` |
+| `app/core/queue.py:55` | `start()` | Starts worker loop |
+| `app/core/queue.py:109` | `_worker_loop()` | Main worker that dequeues and processes |
+| `app/core/queue.py:129` | `_process_request()` | Processes single request with timeout |
+| `app/core/queue.py:174` | `enqueue()` | Adds request to queue |
+| `app/core/queue.py:211` | `submit()` | Enqueue + wait for result |
+| `app/main.py:151-155` | Handler initialization | Queue config passed to handler |
+
+**Concurrency Model:**
+- Semaphore limits concurrent model inference tasks
+- Queue holds pending requests (FIFO)
+- Each request gets a Future that resolves when processed
+- Timeout enforced at request level (default 300s)
+- Memory cleanup via garbage collection every 10 requests
+
+---
+
+## 3. Dataflow Diagram
+
+```
+┌─────────────┐
+│   Client    │
+└──────┬──────┘
+       │ HTTP POST /v1/chat/completions
+       ▼
+┌─────────────────────────────────────┐
+│  FastAPI Router (endpoints.py)      │
+│  - Validates request (Pydantic)     │
+│  - Extracts handler from app.state  │
+└──────┬──────────────────────────────┘
+       │
+       ▼
+┌─────────────────────────────────────┐
+│  Handler (e.g., MLXLMHandler)       │
+│  - generate_text_stream()           │
+│  - Prepares request data            │
+└──────┬──────────────────────────────┘
+       │ queue.submit(request_id, data)
+       ▼
+┌─────────────────────────────────────┐
+│  RequestQueue (queue.py)            │
+│  - Enqueues request                 │
+│  - Worker acquires semaphore        │
+└──────┬──────────────────────────────┘
+       │ _process_request()
+       ▼
+┌─────────────────────────────────────┐
+│  MLX_LM Model (mlx_lm.py)           │
+│  - __call__() invokes mlx-lm        │
+│  - stream_generate() or generate()  │
+└──────┬──────────────────────────────┘
+       │ Response generator/string
+       ▼
+┌─────────────────────────────────────┐
+│  Handler (post-processing)          │
+│  - Parser (tool calls, reasoning)   │
+│  - Yield chunks or final response   │
+└──────┬──────────────────────────────┘
+       │
+       ▼
+┌─────────────────────────────────────┐
+│  FastAPI Router                     │
+│  - StreamingResponse (SSE)          │
+│  - or JSONResponse                  │
+└──────┬──────────────────────────────┘
+       │
+       ▼
+┌─────────────┐
+│   Client    │
+└─────────────┘
+```
+
+---
+
+## 4. API Surface – Existing Endpoints
+
+| Method | Endpoint | Purpose | Handler Method | Notes |
+|--------|----------|---------|----------------|-------|
+| GET | `/health` | Health check | N/A | Always returns 200 OK, no dependencies |
+| GET | `/v1/models` | List available models | `handler.get_models()` | Returns single model loaded at startup |
+| GET | `/v1/queue/stats` | Queue statistics | `handler.get_queue_stats()` | Returns queue size, active requests, max concurrency |
+| POST | `/v1/chat/completions` | Chat completions | `handler.generate_text_stream()` or `handler.generate_text_response()` | Streaming: SSE, Non-streaming: JSON |
+| POST | `/v1/embeddings` | Generate embeddings | `handler.generate_embeddings_response()` | Returns list of embeddings |
+| POST | `/v1/images/generations` | Generate images | `handler.generate_image()` | Flux models only, requires mflux |
+| POST | `/v1/images/edits` | Edit images | `handler.edit_image()` | Flux kontext only, requires mflux |
+| POST | `/v1/audio/transcriptions` | Transcribe audio | `handler.generate_transcription_response()` | Whisper models only |
+
+**Compatibility:**
+- Implements OpenAI API format for requests and responses
+- Supports standard parameters: temperature, top_p, max_tokens, stream, etc.
+- Tool calling via `tools` parameter (with auto-detection of tool call parsers)
+- Function calling format matches OpenAI
+- Streaming uses SSE (Server-Sent Events) with `data: [DONE]` terminator
+
+**Missing OpenAI Endpoints:**
+- No `/v1/completions` (legacy, only chat completions)
+- No `/v1/files`, `/v1/fine-tuning`, `/v1/moderations`, etc.
+- No multi-model management (only single model at startup)
+
+---
+
+## 5. Concurrency & Queue Configuration
+
+### Where Limits Are Set
+
+| Component | Location | Default | Configurable Via |
+|-----------|----------|---------|------------------|
+| **Max Concurrency** | `app/core/queue.py:46` | 1 | `--max-concurrency` CLI arg |
+| **Queue Size** | `app/core/queue.py:48` | 100 | `--queue-size` CLI arg |
+| **Request Timeout** | `app/core/queue.py:47` | 300s | `--queue-timeout` CLI arg |
+| **Semaphore** | `app/core/queue.py:49` | `asyncio.Semaphore(max_concurrency)` | Derived from max-concurrency |
+| **Async Queue** | `app/core/queue.py:50` | `asyncio.Queue(maxsize=queue_size)` | Derived from queue-size |
+
+### How It Works
+
+1. **Semaphore Control**: `app/core/queue.py:138`
+   - `async with self.semaphore:` blocks until a slot is available
+   - Ensures at most `max_concurrency` requests are being processed simultaneously
+   - Default = 1 (sequential processing)
+
+2. **Queue Buffering**: `app/core/queue.py:199`
+   - Requests enqueued into `asyncio.Queue` with max size `queue_size`
+   - If queue full, raises `asyncio.QueueFull` (returns HTTP 429)
+   - Worker loop dequeues and processes FIFO
+
+3. **Timeout Enforcement**: `app/core/queue.py:142-145`
+   - Each request wrapped in `asyncio.wait_for(processor(data), timeout=self.timeout)`
+   - If exceeded, request.set_exception(TimeoutError)
+   - Default = 300s (5 minutes)
+
+4. **Memory Management**:
+   - `app/core/queue.py:171-172`: Garbage collection every 10 processed requests
+   - `app/main.py:232-235`: Memory cleanup every 50 HTTP requests
+   - `app/models/mlx_lm.py:126`: MLX cache cleared after embeddings
+   - Explicit cleanup in request queue on shutdown
+
+### Current Bottlenecks
+
+- **Single concurrency by default**: Only 1 request processed at a time
+- **No persistent queue**: Queue is in-memory, lost on restart
+- **No priority system**: FIFO only, no request prioritization
+- **No request preemption**: Long-running requests block queue
+- **No distributed processing**: Single-node only
+
+### Recommendations for Phase 1
+
+- Increase default `max_concurrency` based on model size and VRAM
+- Add request priority/preemption logic
+- Implement persistent queue (Redis/MongoDB) for job tracking
+- Add model pool management for multi-model serving
+- Expose concurrency metrics via `/v1/queue/stats`
+
+---
+
+## 6. Model Lifecycle & Memory
+
+### Loading (Startup)
+- `app/main.py:85-156`: Lifespan context manager loads model on startup
+- Model loaded **synchronously** during FastAPI lifespan startup
+- No async loading or lazy initialization
+- Model stored in `app.state.handler`
+
+### Inference (Runtime)
+- `app/models/mlx_lm.py:136`: `__call__()` method invokes MLX generation
+- `app/models/mlx_lm.py:180`: Prompt cache created per request
+- Streaming uses generator pattern (low memory footprint)
+- Non-streaming buffers entire response
+
+### Cleanup (Shutdown)
+- `app/main.py:169-182`: Lifespan shutdown calls `handler.cleanup()`
+- `app/handler/mlx_lm.py:352-366`: Handler cleanup stops queue
+- `app/core/queue.py:69-107`: Queue cleanup cancels pending requests
+- `app/main.py:181`: MLX cache cleared, garbage collection forced
+
+### Memory Management
+- `mx.clear_cache()` called periodically and on cleanup
+- `gc.collect()` forced after inference and every N requests
+- Request data explicitly deleted after processing
+- No model unloading/reloading – model stays in memory for server lifetime
+
+---
+
+## 7. Dependencies & Tech Stack
+
+### Core Libraries (pyproject.toml:24-41)
+- **FastAPI** (0.115.14): HTTP server framework
+- **uvicorn** (0.35.0): ASGI server
+- **mlx-lm** (0.28.3): Text-only language models
+- **mlx-vlm** (0.3.6): Multimodal vision-language models
+- **mlx-whisper** (0.4.3): Audio transcription
+- **mlx-embeddings** (0.0.4): Text embeddings
+- **mflux** (optional): Flux image generation
+- **outlines** (1.1.1): Structured output (JSON schema)
+- **loguru** (0.7.3): Logging
+- **click** (8.2.1): CLI framework
+
+### Python Version
+- Requires: >=3.11, <3.13
+- Optimized for Apple Silicon (MLX framework)
+
+---
+
+## 8. Gaps & Future Work (TODOs for Phase 1)
+
+### Model Management
+- [ ] Multi-model registry (load multiple models, route by model ID)
+- [ ] Model hot-swapping (load/unload without restart)
+- [ ] Model metadata API (capabilities, context length, etc.)
+- [ ] Model versioning and aliases
+
+### Queue & Concurrency
+- [ ] Persistent queue (survive restarts)
+- [ ] Request priority/preemption
+- [ ] Distributed queue (multi-node)
+- [ ] Adaptive concurrency (auto-tune based on load)
+- [ ] Request batching for embeddings
+
+### State & Integration
+- [ ] Database integration (MongoDB for Tier 2 MCP)
+- [ ] Job tracking (status, history, logs)
+- [ ] Tier 2 ↔ Tier 3 protocol (state handoff)
+- [ ] Health metrics (latency, throughput, VRAM usage)
+
+### API Enhancements
+- [ ] Batch endpoints (multiple requests in one call)
+- [ ] Model warmup API (preload without request)
+- [ ] Cancel endpoint (abort in-flight requests)
+- [ ] WebSocket streaming (alternative to SSE)
+
+### Observability
+- [ ] Prometheus metrics export
+- [ ] OpenTelemetry traces
+- [ ] Structured logging (JSON)
+- [ ] Request ID tracking across tiers
+
+---
+
+## 9. References
+
+- **Main Entrypoint**: `app/cli.py:145` (`launch` command)
+- **Server Setup**: `app/main.py:189` (`setup_server`)
+- **API Routes**: `app/api/endpoints.py`
+- **Queue Logic**: `app/core/queue.py`
+- **Model Wrappers**: `app/models/*.py`
+- **Handlers**: `app/handler/*.py`
+- **Schemas**: `app/schemas/openai.py`
+- **README**: Project overview, usage examples
+- **pyproject.toml**: Dependencies, scripts, metadata

--- a/docs/HANDOFFS.md
+++ b/docs/HANDOFFS.md
@@ -1,0 +1,206 @@
+# HANDOFFS – Session Log
+
+This document tracks session-to-session handoffs for the `mlx-openai-server-lab` fusion engine project. Each session appends a new entry with discoveries, actions, and next steps.
+
+---
+
+## Session 1: Phase 0 – Engine Warm-Up
+**Date**: 2025-11-16
+**Branch**: `claude/phase0-engine-warmup-012M2QbGXpRukoMy8x4jyVrg`
+**Goal**: Map the existing codebase and document architecture for Phase 1 transformation
+
+### Discoveries
+
+**Architecture Overview:**
+- FastAPI-based OpenAI-compatible API server running on Apple Silicon (MLX)
+- Stateless design: no database, no persistent storage, all config via CLI
+- Single-model-per-instance: model loaded at startup, no runtime switching
+- Async request queue with semaphore-based concurrency control
+- Supports 6 model types: lm, multimodal, embeddings, whisper, image-generation, image-edit
+
+**Key Components Identified:**
+1. **Entrypoints**: CLI via Click (`app/cli.py:145`) or argparse (`app/main.py:50`), script entry in `pyproject.toml:56`
+2. **Model Loading**: Model wrappers in `app/models/` (mlx_lm, mlx_vlm, etc.), handlers in `app/handler/` wrapping models with queue logic
+3. **Configuration**: All via CLI args (no config files), defaults from env vars in `app/models/mlx_lm.py:15-21`
+4. **HTTP Routing**: Single router in `app/api/endpoints.py` with 8 endpoints (health, models, queue stats, chat, embeddings, images, audio)
+5. **Concurrency**: `app/core/queue.py` RequestQueue with `asyncio.Semaphore`, defaults: max_concurrency=1, timeout=300s, queue_size=100
+
+**Current Limitations:**
+- **No model registry**: Can't switch models without restarting server
+- **No persistent queue**: Queue is in-memory, lost on restart
+- **No state management**: Completely stateless (good for Tier 3, but needs Tier 2 integration)
+- **Sequential by default**: max_concurrency=1 means only one request processed at a time
+- **No multi-model support**: Can only load one model per server instance
+- **No job tracking**: No request history, logs, or status persistence
+
+**Code Quality Observations:**
+- Well-structured, clear separation of concerns (models, handlers, API)
+- Good error handling and logging (loguru)
+- Memory-conscious: explicit garbage collection and MLX cache clearing
+- OpenAI compatibility: Follows OpenAI API schemas closely
+- Extensible: Easy to add new model types via handler pattern
+
+### Actions Taken
+
+1. ✅ Scanned repository structure (42 Python files, 8 handler types, 5 model wrappers)
+2. ✅ Identified main entrypoints: `app/cli.py`, `app/main.py`, `pyproject.toml` script entry
+3. ✅ Mapped model loading flow: `app/models/` → `app/handler/` → `app/main.py` lifespan
+4. ✅ Documented config handling: CLI args only, no config files
+5. ✅ Catalogued HTTP endpoints: 8 routes in `app/api/endpoints.py`
+6. ✅ Analyzed concurrency system: RequestQueue with semaphore in `app/core/queue.py`
+7. ✅ Created `docs/FUSION_PHASE0.md` with comprehensive architecture documentation:
+   - Executive summary
+   - High-level code map with exact file paths and line numbers
+   - Dataflow diagram
+   - Complete API surface table
+   - Concurrency configuration details
+   - Model lifecycle and memory management
+   - Dependencies and tech stack
+   - Gaps and future work (TODOs for Phase 1)
+8. ✅ Created `docs/HANDOFFS.md` (this file) for session tracking
+
+### Next Actions for Phase 1: Fusion Engine Transformation
+
+**Goal**: Transform this stateless inference server into a **multi-model fusion engine** that integrates with Tier 2 (MCP) for state management and orchestration.
+
+#### Priority 1: Model Registry & Management
+1. **Implement model registry** (`app/core/model_registry.py`):
+   - Registry class to track loaded models by ID
+   - Support multiple models loaded simultaneously
+   - Model metadata: type, capabilities, context length, VRAM usage
+   - Model loading/unloading API (hot-swap without restart)
+
+2. **Add model routing logic** (`app/api/endpoints.py`):
+   - Route requests to appropriate model by `model` parameter
+   - Validate model exists before processing request
+   - Return 404 if model not found
+
+3. **Create model management endpoints**:
+   - `POST /v1/models/load` – Load a new model
+   - `DELETE /v1/models/{model_id}/unload` – Unload a model
+   - `GET /v1/models/{model_id}/info` – Get model metadata
+   - `GET /v1/models/{model_id}/stats` – Get model usage stats
+
+#### Priority 2: Persistent Queue & Job Tracking
+4. **Integrate MongoDB for job tracking**:
+   - Job schema: request ID, model ID, status, timestamps, input/output
+   - Status enum: queued, processing, completed, failed, cancelled
+   - Store request metadata (no full request body for privacy)
+
+5. **Implement job status API**:
+   - `GET /v1/jobs/{job_id}` – Get job status
+   - `GET /v1/jobs` – List jobs (with filters: status, model, time range)
+   - `DELETE /v1/jobs/{job_id}` – Cancel a job
+
+6. **Persist queue to Redis** (optional):
+   - Replace in-memory queue with Redis-backed queue
+   - Survive restarts without losing pending requests
+   - Enable distributed queue for multi-node setup
+
+#### Priority 3: Tier 2 Integration
+7. **Define Tier 2 ↔ Tier 3 protocol**:
+   - MCP (Tier 2) sends job requests to Tier 3 via HTTP
+   - Tier 3 reports job status back to MCP (webhooks or polling)
+   - Shared MongoDB for state synchronization
+
+8. **Add health metrics endpoint** (`/v1/health/metrics`):
+   - VRAM usage (current, peak)
+   - Model inference latency (p50, p95, p99)
+   - Queue depth and throughput
+   - Active models and concurrency
+
+9. **Implement callback/webhook system**:
+   - Tier 3 notifies Tier 2 when job completes
+   - POST to configurable webhook URL with job result
+   - Retry logic for failed notifications
+
+#### Priority 4: Observability & Performance
+10. **Add Prometheus metrics export** (`/metrics`):
+    - Request rate, error rate, latency
+    - Queue stats (depth, wait time)
+    - Model stats (inference time, VRAM usage)
+    - Memory stats (gc count, cache clears)
+
+11. **Implement request ID tracking**:
+    - Generate unique request ID for each request
+    - Pass request ID to Tier 2 for correlation
+    - Include request ID in all logs
+
+12. **Optimize concurrency defaults**:
+    - Benchmark different concurrency levels for common models
+    - Document recommended concurrency by model size
+    - Consider adaptive concurrency (auto-tune based on VRAM/latency)
+
+#### Priority 5: Code Refactoring (Low Priority)
+13. **Extract config to dataclass** (optional):
+    - Centralize all config in `app/core/config.py`
+    - Replace arg parsing with pydantic settings
+    - Support config file loading (YAML/TOML)
+
+14. **Add integration tests**:
+    - Test multi-model loading and routing
+    - Test job tracking and status updates
+    - Test Tier 2 integration (mock MCP)
+
+15. **Document Tier 2 ↔ Tier 3 contract**:
+    - API spec for job submission
+    - Job status schema
+    - Webhook payload format
+
+### Risks & Open Questions
+
+**Risks:**
+1. **VRAM constraints**: Loading multiple models simultaneously may exceed available VRAM
+   - *Mitigation*: Implement model LRU eviction, lazy loading, or VRAM monitoring
+2. **Concurrency complexity**: Managing multiple models with different concurrency limits
+   - *Mitigation*: Per-model queue configuration, global semaphore for VRAM
+3. **State synchronization**: Keeping Tier 2 and Tier 3 state consistent
+   - *Mitigation*: Single source of truth (MongoDB), atomic operations, idempotency
+
+**Open Questions:**
+1. Should Tier 3 own the model registry, or should Tier 2 dictate which models to load?
+   - *Recommendation*: Tier 2 owns configuration, Tier 3 manages lifecycle
+2. How to handle model loading failures (e.g., out of VRAM)?
+   - *Recommendation*: Return 503 Service Unavailable, log error, notify Tier 2
+3. Should job history be stored indefinitely, or pruned after N days?
+   - *Recommendation*: Configurable TTL (e.g., 7 days), archive to S3/disk if needed
+4. Should Tier 3 support streaming to Tier 2, or only non-streaming?
+   - *Recommendation*: Support both, use SSE for streaming, JSON for non-streaming
+5. How to handle model version updates (e.g., model repo changes)?
+   - *Recommendation*: Treat as new model ID, allow side-by-side deployment, manual cutover
+
+### Files Changed
+- ✅ Created `docs/FUSION_PHASE0.md` (architecture documentation)
+- ✅ Created `docs/HANDOFFS.md` (session log, this file)
+
+### Files to Change in Phase 1
+- `app/core/model_registry.py` (NEW) – Model registry implementation
+- `app/core/job_tracker.py` (NEW) – MongoDB job tracking
+- `app/api/endpoints.py` – Add model management and job status endpoints
+- `app/main.py` – Update lifespan to support multi-model loading
+- `app/handler/*.py` – Update handlers to report job status
+- `app/schemas/openai.py` – Add job status schemas
+- `README.md` – Update with new multi-model capabilities
+- `docs/TIER2_INTEGRATION.md` (NEW) – Document Tier 2 ↔ Tier 3 protocol
+
+---
+
+## Session 2: TBD
+**Date**: TBD
+**Branch**: TBD
+**Goal**: TBD
+
+### Discoveries
+(Append here)
+
+### Actions Taken
+(Append here)
+
+### Next Actions
+(Append here)
+
+### Risks & Open Questions
+(Append here)
+
+### Files Changed
+(Append here)


### PR DESCRIPTION
Added comprehensive documentation for mlx-openai-server-lab Tier 3 engine:

- FUSION_PHASE0.md: Complete technical architecture documentation
  * Entrypoints (CLI, server setup, lifespan management)
  * Model loading and registry (6 model types, handler pattern)
  * Configuration (CLI args, env vars, no config files)
  * HTTP routing (8 OpenAI-compatible endpoints)
  * Concurrency system (RequestQueue, semaphore, defaults)
  * Dataflow diagram and API surface table
  * Memory management and model lifecycle
  * Current limitations and gaps analysis

- HANDOFFS.md: Session-to-session tracking log
  * Session 1 summary with discoveries and actions
  * 15 concrete next actions for Phase 1 (multi-model registry, job tracking, Tier 2 integration)
  * Risks and open questions documented
  * Template for future sessions

Phase 0 complete. Ready for Phase 1: Fusion Engine transformation.