### PR TITLE
Implement pre-commit and linting GitHub action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,51 @@
+name: Linters
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  linters:
+    name: Run Linters
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Debug GitHub Variables
+        run: |
+          echo "github.event_name: ${{ github.event_name }}"
+          echo "github.ref_name: ${{ github.ref_name }}"
+          echo "github.event.repository.default_branch: ${{ github.event.repository.default_branch }}"
+
+      - name: Setup Python 3 (with caching)
+        uses: actions/setup-python@v6
+        id: setup-python
+        with:
+          python-version: 3.12
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Install Linting Requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install --group dev -e .
+
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pre-commit
+          key: ${{ runner.os }}-lint-py${{ steps.setup-python.outputs.python-version || '3.x' }}-${{ hashFiles('**/.pre-commit-config.yaml', '**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-lint-
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+
+      - uses: pre-commit-ci/lite-action@v1.1.0
+        if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,52 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: '.*\.md$'
+      - id: end-of-file-fixer
+        exclude: '.*\.md$'
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-merge-conflict
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.9
+    hooks:
+      - id: actionlint
+
+    # Note: shellcheck cannot directly parse YAML; actionlint extracts workflow
+    # shell blocks and calls shellcheck when available.
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        # Match by detected shell file type (extensions or shebang)
+        types: [shell]
+        args: ['-x']
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.6
+    hooks:
+      # Run the linter.
+      - id: ruff-check
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
+
+ci:
+  autofix_prs: true
+  autoupdate_schedule: weekly
+  skip: []
+  submodules: false


### PR DESCRIPTION
### This should not be merged until the project linting/formatting has been changed over to ruff

I recommend that you install `pre-commit.ci` into your GitHub account and allow it to run at least this repo (or all of your repos if you'd like).
* Go to https://pre-commit.ci/ and select `Sign In with GitHub`

-----

This pull request sets up automated dependency updates and linting for the repository, introducing configuration files for Dependabot, GitHub Actions-based linters, and pre-commit hooks. These changes help ensure code quality and keep dependencies up-to-date with minimal manual intervention.

**Automated Dependency Management:**
* Added `.github/dependabot.yml` to enable weekly automated updates for GitHub Actions and Python (`pip`) dependencies, with a limit of 10 open pull requests per ecosystem.

**Linting Workflow Integration:**
* Created `.github/workflows/linters.yml` to run linters automatically on pull requests and pushes to `main`, including Python environment setup, caching, and pre-commit checks.

**Pre-commit Hooks Configuration:**
* Introduced `.pre-commit-config.yaml` specifying a range of pre-commit hooks for code quality (whitespace, file endings, YAML/TOML validity, large files, merge conflicts, shell scripts, spelling, and Python linting/formatting). Also configures automated autofix PRs and weekly updates for hooks.