### PR TITLE
Add Nemotron3 Nano parsers and update parser registry

### DIFF
--- a/app/handler/parser/__init__.py
+++ b/app/handler/parser/__init__.py
@@ -9,6 +9,7 @@ from .minimax import MinimaxToolParser, MinimaxThinkingParser, MiniMaxMessageCon
 from .hermes import HermesToolParser, HermesThinkingParser
 from .llama4_pythonic import Llama4PythonicToolParser
 from .ministral3 import Ministral3ToolParser, Ministral3ThinkingParser
+from .nemotron3_nano import Nemotron3NanoToolParser, Nemotron3NanoThinkingParser
 from .factory import ParserFactory
 
 __all__ = [
@@ -32,5 +33,7 @@ __all__ = [
     'Llama4PythonicToolParser',
     'Ministral3ThinkingParser',
     'Ministral3ToolParser',
+    'Nemotron3NanoToolParser',
+    'Nemotron3NanoThinkingParser',
     'ParserFactory',
 ]

--- a/app/handler/parser/factory.py
+++ b/app/handler/parser/factory.py
@@ -28,6 +28,8 @@ from . import (
     Llama4PythonicToolParser,
     Ministral3ThinkingParser,
     Ministral3ToolParser,
+    Nemotron3NanoToolParser,
+    Nemotron3NanoThinkingParser,
 )
 from .glm4_moe import Glm4MoEMessageConverter
 from .minimax import MiniMaxMessageConverter
@@ -72,6 +74,10 @@ PARSER_REGISTRY: Dict[str, Dict[str, Callable]] = {
     "ministral3": {
         "thinking": Ministral3ThinkingParser,
         "tool": Ministral3ToolParser,
+    },
+    "nemotron3_nano": {
+        "thinking": Nemotron3NanoThinkingParser,
+        "tool": Nemotron3NanoToolParser,
     },
 }
 
@@ -126,6 +132,11 @@ PARSER_METADATA: Dict[str, Dict[str, Any]] = {
     "llama4_pythonic": {
         "respects_enable_thinking": False,
         "needs_redacted_reasoning_prefix": False,
+        "has_special_parsing": False,
+    },
+    "nemotron3_nano": {
+        "respects_enable_thinking": True,
+        "needs_redacted_reasoning_prefix": True,
         "has_special_parsing": False,
     },
 }

--- a/app/handler/parser/nemotron3_nano.py
+++ b/app/handler/parser/nemotron3_nano.py
@@ -1,0 +1,85 @@
+import re
+from typing import Any, Dict, Optional
+from .base import BaseToolParser, BaseThinkingParser
+
+TOOL_OPEN = "<tool_call>"
+TOOL_CLOSE = "</tool_call>"
+THINKING_OPEN = "<think>"
+THINKING_CLOSE = "</think>"
+
+
+class Nemotron3NanoThinkingParser(BaseThinkingParser):
+    """Parser for Nemotron3 Nano model's thinking response format."""
+    
+    def __init__(self):
+        super().__init__(
+            thinking_open=THINKING_OPEN,
+            thinking_close=THINKING_CLOSE
+        )
+
+
+class Nemotron3NanoToolParser(BaseToolParser):
+    """Parser for Nemotron3 Nano model's tool response format.
+    
+    Handles tool calls in the format:
+    <tool_call>
+    <function=function_name>
+    <parameter=param_name>
+    param_value
+    </parameter>
+    </function>
+    </tool_call>
+    """
+    
+    def __init__(self):
+        super().__init__(
+            tool_open=TOOL_OPEN,
+            tool_close=TOOL_CLOSE   
+        )
+        # Regex pattern to extract function name and content
+        self.function_regex = re.compile(
+            r"<function=([^>]+)>\s*(.*?)\s*</function>", 
+            re.DOTALL
+        )
+        # Regex pattern to extract parameter key-value pairs
+        self.parameter_regex = re.compile(
+            r"<parameter=([^>]+)>\s*(.*?)\s*</parameter>",
+            re.DOTALL
+        )
+    
+    def _parse_tool_content(self, tool_content: str) -> Optional[Dict[str, Any]]:
+        """Parse Nemotron3 Nano's XML-style tool call format.
+        
+        Parameters
+        ----------
+        tool_content : str
+            The content between <tool_call> tags.
+            
+        Returns
+        -------
+        Dict[str, Any] or None
+            Dictionary containing 'name' and 'arguments', or None if parsing fails.
+        """
+        try:
+            # Extract function name and its content
+            function_match = self.function_regex.search(tool_content)
+            if not function_match:
+                return None
+            
+            function_name = function_match.group(1).strip()
+            function_content = function_match.group(2)
+            
+            # Extract all parameters
+            arguments = {}
+            for param_match in self.parameter_regex.finditer(function_content):
+                param_name = param_match.group(1).strip()
+                param_value = param_match.group(2).strip()
+                arguments[param_name] = param_value
+            
+            return {
+                "name": function_name,
+                "arguments": arguments
+            }
+        except Exception as e:
+            print(f"Error parsing Nemotron3 Nano tool call: {tool_content}, Error: {e}")
+            return None


### PR DESCRIPTION
# Add Nemotron3 Nano parser support

## Summary

This PR adds support for parsing structured outputs (tool calls and thinking/reasoning) from the Nemotron3 Nano model. The implementation includes two new parser classes that handle Nemotron3 Nano's unique XML-style format for tool calls and reasoning responses.

## Changes

### New Files
- **`app/handler/parser/nemotron3_nano.py`**: Implements two parser classes:
  - `Nemotron3NanoThinkingParser`: Parses thinking/reasoning responses wrapped in `<think>` tags
  - `Nemotron3NanoToolParser`: Parses tool calls in Nemotron3 Nano's custom XML format with `<tool_call>`, `<function>`, and `<parameter>` tags

### Modified Files
- **`app/handler/parser/__init__.py`**: Added imports and exports for the new parser classes
- **`app/handler/parser/factory.py`**: 
  - Registered `nemotron3_nano` in `PARSER_REGISTRY` with both thinking and tool parsers
  - Added parser metadata indicating:
    - Respects `enable_thinking` flag: `True`
    - Needs `redacted_reasoning` prefix: `True`
    - Has special parsing logic: `False`

## Technical Details

### Tool Call Format

Nemotron3 Nano uses a custom XML-style format for tool calls:

```xml
<tool_call>
<function=function_name>
<parameter=param_name>
param_value
</parameter>
</function>
</tool_call>
```

The `Nemotron3NanoToolParser` uses regex patterns to extract:
- Function name from `<function=...>` tags
- Parameter key-value pairs from nested `<parameter=...>` tags

### Thinking Format

Thinking/reasoning content is wrapped in `<think>` tags:
- Opening: `<think>`
- Closing: `</think>`

The `Nemotron3NanoThinkingParser` extends `BaseThinkingParser` with these tag definitions.