### PR TITLE
(fix) parser: minimax - tool arguments json

### DIFF
--- a/app/handler/parser/minimax.py
+++ b/app/handler/parser/minimax.py
@@ -78,7 +78,7 @@ class MinimaxToolParser(BaseToolParser):
             # Build tool call object
             return {
                 "name": func_name,
-                "arguments": arguments
+                "arguments": json.dumps(arguments)
             }
         except Exception as e:
             print(f"Error parsing MiniMax tool call content: {tool_content}, Error: {e}")


### PR DESCRIPTION
### Description:
problem: Minimax M2.1 with `opencode` - any tool call arguments is invalid json, result in an `opencode` error like below,
hence the model can't use any tool
```
invalid [tool=read, error=Invalid input for tool read: JSON parsing failed: Text: {'filePath': '/Users/me/projects/cool/src/store/search/search.constant.js'}.
Error message: JSON Parse error: Single quotes (') are not allowed in JSON]
```
* parser: minimax - return tool function arguments as "json" string
> with that my local Minimax M2.1 works fine