### PR TITLE
Implement Nemotron3 Nano parsers for reasoning and tool calls

### DIFF
--- a/app/parsers/nemotron3_nano.py
+++ b/app/parsers/nemotron3_nano.py
@@ -1,19 +1,40 @@
 from __future__ import annotations
 
 import re
+import json
 
 from .hermes import HermesReasoningParser
 from .glm4_moe import GLM4MoEToolParser
 
+
+REASONING_OPEN = "<think>"
+REASONING_CLOSE = "</think>"
 TOOL_OPEN = "<tool_call>"
 TOOL_CLOSE = "</tool_call>"
 
-Nemotron3NanoReasoningParser = HermesReasoningParser
+class Nemotron3NanoReasoningParser(HermesReasoningParser):
+    """Parser for Nemotron3 Nano model's reasoning response format."""
+    
+    def __init__(self):
+        super().__init__(
+            reasoning_open=REASONING_OPEN,
+            reasoning_close=REASONING_CLOSE
+        )
+
+    def needs_redacted_reasoning_prefix(self) -> bool:
+        """Check if the reasoning parser needs a redacted reasoning prefix.
+        
+        Returns
+        -------
+        bool
+            True if the reasoning parser needs a redacted reasoning prefix, False otherwise.
+        """
+        return True
+
 
 class Nemotron3NanoToolParser(GLM4MoEToolParser):
-    """Tool parser for Nemotron3 Nano model's tool response format.
-
-    Handles the Nemotron3 Nano model's tool response format:
+    """Parser for Nemotron3 Nano model's tool response format.
+    Handles tool calls in the format:
     <tool_call>
     <function=function_name>
     <parameter=param_name>
@@ -23,17 +44,64 @@ class Nemotron3NanoToolParser(GLM4MoEToolParser):
     </tool_call>
     """
 
-    def __init__(self, tool_open: str = TOOL_OPEN, tool_close: str = TOOL_CLOSE) -> None:
-        """Initialize the Nemotron3 Nano tool parser with appropriate regex patterns."""
-        super().__init__(tool_open=tool_open, tool_close=tool_close)
-        
+    def __init__(self):
+        super().__init__(
+            tool_open=TOOL_OPEN,
+            tool_close=TOOL_CLOSE
+        )
         # Regex pattern to extract function name and content
-        self.func_call_regex = re.compile(
-            r"<function=([^>]+)>\s*(.*?)\s*</function>", 
+        self.tool_regex = re.compile(
+            r"<function=([^>]+)>\s*(.*?)\s*</function>",
             re.DOTALL
         )
         # Regex pattern to extract parameter key-value pairs
-        self.func_arg_regex = re.compile(
+        self.parameter_regex = re.compile(
             r"<parameter=([^>]+)>\s*(.*?)\s*</parameter>",
             re.DOTALL
         )
+
+    def extract_tool_calls(self, model_output: str) -> dict[str, list] | None:
+        """Extract tool calls from complete model output.
+        
+        Parameters
+        ----------
+        model_output : str
+            Complete model output containing tool calls in XML-like format.
+            
+        Returns
+        -------
+        dict[str, list] | None
+            Dictionary with 'tool_calls' key containing list of parsed tool calls,
+            or None if no tool calls found. Each tool call has 'name' and 'arguments'.
+        """
+        matches = self.tool_regex.findall(model_output)
+        if not matches:
+            return {
+                "content": model_output
+            }
+        
+        tool_calls = []
+        for match in matches:
+            function_name = match[0].strip()
+            function_content = match[1].strip()
+            
+            # Extract parameters from function content
+            param_matches = self.parameter_regex.findall(function_content)
+            arguments = {}
+            for param_match in param_matches:
+                param_name = param_match[0].strip()
+                param_value = param_match[1].strip()
+                
+                # Try to parse the value as JSON (for numbers, booleans, objects, arrays)
+                try:
+                    arguments[param_name] = json.loads(param_value)
+                except (json.JSONDecodeError, ValueError):
+                    # If JSON parsing fails, use the raw string value
+                    arguments[param_name] = param_value
+            
+            tool_calls.append({
+                "name": function_name,
+                "arguments": json.dumps(arguments),
+            })
+        
+        return {"tool_calls": tool_calls}


### PR DESCRIPTION
- Created `Nemotron3NanoReasoningParser` to handle reasoning responses with custom open and close tags.
- Developed `Nemotron3NanoToolParser` for parsing tool calls, including regex patterns for function names and parameters.
- Added method to extract tool calls from model output, supporting JSON parsing for parameter values.
- Enhanced documentation for clarity on parser functionality and expected output structure.