### PR TITLE
(fix) Qwen3 Coder: tool parser and message converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ mlx-openai-server launch \
 - `--host`: Host to run the server on (default: 0.0.0.0)
 - `--disable-auto-resize`: Disable automatic model resizing. Only works for Vision Language Models.
 - `--enable-auto-tool-choice`: Enable automatic tool choice. Only works with language models (`lm` or `multimodal` model types).
-- `--tool-call-parser`: Specify tool call parser to use instead of auto-detection. Only works with language models (`lm` or `multimodal` model types). Available options: `qwen3`, `glm4_moe`, `qwen3_moe`, `qwen3_next`, `qwen3_vl`, `harmony`, `minimax_m2`.
+- `--tool-call-parser`: Specify tool call parser to use instead of auto-detection. Only works with language models (`lm` or `multimodal` model types). Available options: `qwen3`, `glm4_moe`, `qwen3_coder`, `qwen3_moe`, `qwen3_next`, `qwen3_vl`, `harmony`, `minimax_m2`.
 - `--reasoning-parser`: Specify reasoning parser to use instead of auto-detection. Only works with language models (`lm` or `multimodal` model types). Available options: `qwen3`, `glm4_moe`, `qwen3_moe`, `qwen3_next`, `qwen3_vl`, `harmony`, `minimax_m2`.
 - `--message-converter`: Specify message converter to use for preprocessing messages. Only works with language models (`lm` or `multimodal` model types). Available options: `glm4_moe`, `minimax_m2`, `nemotron3_nano`. This converts OpenAI API format messages to model-specific format requirements.
 - `--trust-remote-code`: Enable `trust_remote_code` when loading models. This allows loading custom code from model repositories. Default: `False` (disabled). Only works with `lm` or `multimodal` model types.
@@ -440,6 +440,7 @@ The following parsers are available for both tool call and reasoning parsing:
 
 - **`qwen3`**: Parser for Qwen3 model formats
 - **`glm4_moe`**: Parser for GLM4 MoE model formats
+- **`qwen3_coder`**: Parser for Qwen3 Coder model formats (note: only tool-parser, the model lacks `<think>` blocks)
 - **`qwen3_moe`**: Parser for Qwen3 MoE model formats
 - **`qwen3_next`**: Parser for Qwen3 Next model formats
 - **`qwen3_vl`**: Parser for Qwen3 Vision-Language model formats
@@ -461,6 +462,7 @@ Message converters transform OpenAI API format messages into model-specific form
 - **`glm4_moe`**: Converter for GLM4 MoE models (converts function arguments from string to object format)
 - **`minimax`** or **`minimax_m2`**: Converter for MiniMax models (converts function arguments from string to object format)
 - **`nemotron3_nano`**: Converter for Nemotron3 Nano models (converts function arguments from string to object format)
+- **`qwen3_coder`**: Converter for Qwen3 Coder models (converts function arguments from string to object format)
 
 #### Message Converter Parameter
 

--- a/app/message_converters/__init__.py
+++ b/app/message_converters/__init__.py
@@ -6,6 +6,7 @@ from .abstract_converter import AbstractMessageConverter
 from .glm4_moe import GLM4MoEMessageConverter
 from .minimax_m2 import MiniMaxM2MessageConverter
 from .nemontron3_nano import Nemotron3NanoMessageConverter
+from .qwen3_coder import Qwen3CoderMessageConverter
 
 # Mapping from converter name strings to converter classes
 MESSAGE_CONVERTER_MAP: dict[str, type[AbstractMessageConverter]] = {
@@ -13,6 +14,7 @@ MESSAGE_CONVERTER_MAP: dict[str, type[AbstractMessageConverter]] = {
     "minimax_m2": MiniMaxM2MessageConverter,
     "minimax": MiniMaxM2MessageConverter,  # Alias for minimax_m2
     "nemotron3_nano": Nemotron3NanoMessageConverter,
+    "qwen3_coder": Qwen3CoderMessageConverter,
 }
 
 
@@ -77,6 +79,7 @@ __all__ = [
     "GLM4MoEMessageConverter",
     "MiniMaxM2MessageConverter",
     "Nemotron3NanoMessageConverter",
+    "Qwen3CoderMessageConverter",
     # Mapping and helper functions
     "MESSAGE_CONVERTER_MAP",
     "get_message_converter",

--- a/app/message_converters/qwen3_coder.py
+++ b/app/message_converters/qwen3_coder.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .glm4_moe import GLM4MoEMessageConverter
+
+Qwen3CoderMessageConverter = GLM4MoEMessageConverter

--- a/app/parsers/__init__.py
+++ b/app/parsers/__init__.py
@@ -16,6 +16,7 @@ from .hermes import HermesReasoningParser, HermesToolParser
 from .minimax_m2 import MiniMaxM2ReasoningParser, MiniMaxM2ToolParser
 from .nemotron3_nano import Nemotron3NanoReasoningParser, Nemotron3NanoToolParser
 from .qwen3 import Qwen3ReasoningParser, Qwen3ToolParser
+from .qwen3_coder import Qwen3CoderToolParser
 from .qwen3_moe import Qwen3MoEReasoningParser, Qwen3MoEToolParser
 from .qwen3_vl import Qwen3VLReasoningParser, Qwen3VLToolParser
 from .iquest_coder_v1 import IQuestCoderV1ToolParser
@@ -35,6 +36,7 @@ REASONING_PARSER_MAP: dict[str, type[AbstractReasoningParser]] = {
 TOOL_PARSER_MAP: dict[str, type[AbstractToolParser]] = {
     "hermes": HermesToolParser,
     "qwen3": Qwen3ToolParser,
+    "qwen3_coder": Qwen3CoderToolParser,
     "qwen3_moe": Qwen3MoEToolParser,
     "qwen3_vl": Qwen3VLToolParser,
     "glm4_moe": GLM4MoEToolParser,
@@ -295,6 +297,7 @@ __all__ = [
     # Tool parsers
     "HermesToolParser",
     "Qwen3ToolParser",
+    "Qwen3CoderToolParser",
     "Qwen3MoEToolParser",
     "Qwen3VLToolParser",
     "GLM4MoEToolParser",

--- a/app/parsers/qwen3_coder.py
+++ b/app/parsers/qwen3_coder.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import re
+import json
+
+from .glm4_moe import GLM4MoEToolParser
+
+
+TOOL_OPEN = "<tool_call>"
+TOOL_CLOSE = "</tool_call>"
+
+class Qwen3CoderToolParser(GLM4MoEToolParser):
+    """Parser for Qwen3 Coder model's tool response format.
+    Handles tool calls in the format:
+    <tool_call>
+    <function=function_name>
+    <parameter=param_name>
+    param_value
+    </parameter>
+    </function>
+    </tool_call>
+    """
+
+    def __init__(self):
+        super().__init__(
+            tool_open=TOOL_OPEN,
+            tool_close=TOOL_CLOSE
+        )
+        # Regex pattern to extract function name and content
+        self.tool_regex = re.compile(
+            r"<function=([^>]+)>\s*(.*?)\s*</function>",
+            re.DOTALL
+        )
+        # Regex pattern to extract parameter key-value pairs
+        self.parameter_regex = re.compile(
+            r"<parameter=([^>]+)>\s*(.*?)\s*</parameter>",
+            re.DOTALL
+        )
+
+    def extract_tool_calls(self, model_output: str) -> dict[str, list] | None:
+        """Extract tool calls from complete model output.
+
+        Parameters
+        ----------
+        model_output : str
+            Complete model output containing tool calls in XML-like format.
+
+        Returns
+        -------
+        dict[str, list] | None
+            Dictionary with 'tool_calls' key containing list of parsed tool calls,
+            or None if no tool calls found. Each tool call has 'name' and 'arguments'.
+        """
+        matches = self.tool_regex.findall(model_output)
+        if not matches:
+            return {
+                "content": model_output
+            }
+
+        tool_calls = []
+        for match in matches:
+            function_name = match[0].strip()
+            function_content = match[1].strip()
+
+            # Extract parameters from function content
+            param_matches = self.parameter_regex.findall(function_content)
+            arguments = {}
+            for param_match in param_matches:
+                param_name = param_match[0].strip()
+                param_value = param_match[1].strip()
+
+                # Try to parse the value as JSON (for numbers, booleans, objects, arrays)
+                try:
+                    arguments[param_name] = json.loads(param_value)
+                except (json.JSONDecodeError, ValueError):
+                    arguments[param_name] = param_value
+
+            tool_calls.append({
+                "name": function_name,
+                "arguments": json.dumps(arguments),
+            })
+
+        return {"tool_calls": tool_calls}


### PR DESCRIPTION
### Description:
problem: Qwen3 Coder models can't use tools (tested with `opencode`)

* (fix) parsers: add Qwen3 Coder tool only implementation (same as Nemotron)
* (fix)message-converter: add Qwen3 Coder (reuse GLM4MoEMessageConverter)
* (doc) README: update cli usage

#### works now for me with `opencode` - all tools run correct:
```bash
% python -m app.main --model-path ../../my-Qwen3-Coder-30B-A3B-Instruct-bf16 \
    --model-type lm \
    --enable-auto-tool-choice \
    --tool-call-parser qwen3_coder \
    --message-converter qwen3_coder
```

based on prev impl https://github.com/cubist38/mlx-openai-server/pull/125