### PR TITLE
Refactor context length handling in model initialization

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -101,9 +101,9 @@ def cli():
 )
 @click.option(
     "--context-length",
-    default=32768,
+    default=None,
     type=int,
-    help="Context length for language models. Only works with `lm` or `multimodal` model types.",
+    help="Context length for language models. If not specified, uses model default. Only works with `lm` or `multimodal` model types.",
 )
 @click.option("--port", default=8000, type=int, help="Port to run the server on")
 @click.option("--host", default="0.0.0.0", help="Host to run the server on")

--- a/app/config.py
+++ b/app/config.py
@@ -23,7 +23,7 @@ class MLXServerConfig:
 
     model_path: str
     model_type: str = "lm"
-    context_length: int = 32768
+    context_length: int | None = None
     port: int = 8000
     host: str = "0.0.0.0"
     max_concurrency: int = 1

--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -21,13 +21,13 @@ class MLXLMHandler:
     Provides request queuing, metrics tracking, and robust error handling.
     """
 
-    def __init__(self, model_path: str, context_length: int = 32768, max_concurrency: int = 1, enable_auto_tool_choice: bool = False, tool_call_parser: str = None, reasoning_parser: str = None, message_converter: str = None, trust_remote_code: bool = False, chat_template_file: str = None, debug: bool = False):
+    def __init__(self, model_path: str, context_length: int | None = None, max_concurrency: int = 1, enable_auto_tool_choice: bool = False, tool_call_parser: str = None, reasoning_parser: str = None, message_converter: str = None, trust_remote_code: bool = False, chat_template_file: str = None, debug: bool = False):
         """
         Initialize the handler with the specified model path.
         
         Args:
             model_path (str): Path to the model directory.
-            context_length (int): Maximum context length for the model.
+            context_length (int | None): Maximum context length for the model. If None, uses model default.
             max_concurrency (int): Maximum number of concurrent model inference tasks.
             enable_auto_tool_choice (bool): Enable automatic tool choice.
             tool_call_parser (str): Name of the tool call parser to use (qwen3, glm4_moe, harmony, minimax, ...)

--- a/app/handler/mlx_vlm.py
+++ b/app/handler/mlx_vlm.py
@@ -28,13 +28,13 @@ class MLXVLMHandler:
     Provides caching, concurrent image processing, audio processing, and robust error handling.
     """
 
-    def __init__(self, model_path: str, context_length: int = 32768, max_workers: int = 4, max_concurrency: int = 1, disable_auto_resize: bool = False, enable_auto_tool_choice: bool = False, tool_call_parser: str = None, reasoning_parser: str = None, message_converter: str = None, trust_remote_code: bool = False, chat_template_file: str = None, debug: bool = False):
+    def __init__(self, model_path: str, context_length: int | None = None, max_workers: int = 4, max_concurrency: int = 1, disable_auto_resize: bool = False, enable_auto_tool_choice: bool = False, tool_call_parser: str = None, reasoning_parser: str = None, message_converter: str = None, trust_remote_code: bool = False, chat_template_file: str = None, debug: bool = False):
         """
         Initialize the handler with the specified model path.
         
         Args:
             model_path (str): Path to the model directory.
-            context_length (int): Maximum context length for the model.
+            context_length (int | None): Maximum context length for the model. If None, uses model default.
             max_workers (int): Maximum number of worker threads for image processing.
             max_concurrency (int): Maximum number of concurrent model inference tasks.
             disable_auto_resize (bool): Whether to disable automatic image resizing.

--- a/app/models/mlx_lm.py
+++ b/app/models/mlx_lm.py
@@ -51,7 +51,7 @@ class MLX_LM:
     supporting both streaming and non-streaming modes.
     """
 
-    def __init__(self, model_path: str, context_length: int = 32768, trust_remote_code: bool = False, chat_template_file: str = None):
+    def __init__(self, model_path: str, context_length: int | None = None, trust_remote_code: bool = False, chat_template_file: str = None):
         try:
             self.model, self.tokenizer = load(model_path, lazy=False, tokenizer_config = {"trust_remote_code": trust_remote_code})
             self.pad_token_id = self.tokenizer.pad_token_id
@@ -68,7 +68,7 @@ class MLX_LM:
             raise ValueError(f"Error loading model: {str(e)}")
 
     def create_prompt_cache(self) -> List[Any]:
-        return make_prompt_cache(self.model, self.context_length)
+        return make_prompt_cache(self.model, max_kv_size=self.context_length)
         
     def get_model_type(self) -> str:
         return self.model_type

--- a/app/models/mlx_vlm.py
+++ b/app/models/mlx_vlm.py
@@ -45,13 +45,13 @@ class MLX_VLM:
     supporting both streaming and non-streaming modes.
     """
     
-    def __init__(self, model_path: str, context_length: int = 32768, trust_remote_code: bool = False, chat_template_file: str = None):
+    def __init__(self, model_path: str, context_length: int | None = None, trust_remote_code: bool = False, chat_template_file: str = None):
         """
         Initialize the MLX_VLM model.
         
         Args:
             model_path (str): Path to the model directory containing model weights and configuration.
-            context_length (int): Maximum context length for the model. Defaults to 32768.
+            context_length (int | None): Maximum context length for the model. If None, uses model default.
             trust_remote_code (bool): Enable trust_remote_code when loading models. Defaults to False.
         Raises:
             ValueError: If model loading fails.
@@ -77,7 +77,7 @@ class MLX_VLM:
         return self.config.model_type
 
     def create_prompt_cache(self) -> List[Any]:
-        return make_prompt_cache(self.model.language_model, self.context_length)
+        return make_prompt_cache(self.model.language_model, max_kv_size=self.context_length)
 
     def create_input_prompt(self, messages: List[Dict[str, str]], chat_template_kwargs: Dict[str, Any]) -> str:
         return self.processor.apply_chat_template(


### PR DESCRIPTION
## Summary

This PR refactors context length handling to allow models to use their native default context lengths instead of forcing a hardcoded value of 32768 tokens. This improves flexibility and ensures models operate with their intended configuration.

## Changes

- **Default behavior update**: Changed `context_length` parameter default from `32768` to `None` across all model handlers and initialization code
- **Type annotation improvements**: Updated type hints to `int | None` for context_length parameters throughout the codebase
- **Enhanced documentation**: Updated docstrings and CLI help text to clarify that when `context_length` is not specified, the model's default configuration is used
- **Clearer API usage**: Updated `make_prompt_cache()` calls to use the explicit `max_kv_size` parameter name instead of positional arguments

## Files Modified

- `app/cli.py` - CLI argument default and help text
- `app/config.py` - Configuration default value and type annotation
- `app/handler/mlx_lm.py` - Handler initialization signature and documentation
- `app/handler/mlx_vlm.py` - Handler initialization signature and documentation
- `app/models/mlx_lm.py` - Model initialization and prompt cache creation
- `app/models/mlx_vlm.py` - Model initialization and prompt cache creation

## Benefits

1. **Model-specific optimization**: Each model now uses its intended context length rather than a one-size-fits-all value
2. **Backward compatibility**: Users can still explicitly set `--context-length` if needed for specific use cases
3. **Reduced memory usage**: Models with smaller native context lengths won't unnecessarily allocate memory for 32K tokens
4. **Better clarity**: The intent of the parameter is clearer through improved documentation and explicit parameter naming