### PR TITLE
Fix MiniMax M2 parser failing to parse multi-line HTML content in parameters

### DIFF
--- a/app/parsers/minimax_m2.py
+++ b/app/parsers/minimax_m2.py
@@ -51,5 +51,5 @@ class MiniMaxM2ToolParser(GLM4MoEToolParser):
             r'<invoke name="([^"]+)"\s*>(.*)', re.DOTALL
         )
         self.func_arg_regex = re.compile(
-            r'<parameter name="([^"]+)"\s*>([^<]*)</parameter>', re.DOTALL
+            r'<parameter name="([^"]+)"\s*>(.*?)</parameter>', re.DOTALL
         )


### PR DESCRIPTION
The func_arg_regex pattern was using ([^<]*) which excludes '<' characters, causing it to truncate parameter values at the first '<'. This prevented the parser from correctly extracting HTML content or any parameter values containing angle brackets.

Changed the pattern from ([^<]*) to (.*?) to use a non-greedy match that captures all content until the closing </parameter> tag. This allows the parser to correctly handle multi-line HTML, XML, and any other content containing '<' characters.

Closes #163