### PR TITLE
feat(api): add XTC sampling and logit_bias parameters

### DIFF
--- a/app/models/mlx_lm.py
+++ b/app/models/mlx_lm.py
@@ -16,6 +16,8 @@ DEFAULT_TEMPERATURE = os.getenv("DEFAULT_TEMPERATURE", 0.7)
 DEFAULT_TOP_P = os.getenv("DEFAULT_TOP_P", 0.95)
 DEFAULT_TOP_K = os.getenv("DEFAULT_TOP_K", 20)
 DEFAULT_MIN_P = os.getenv("DEFAULT_MIN_P", 0.0)
+DEFAULT_XTC_PROBABILITY = os.getenv("DEFAULT_XTC_PROBABILITY", 0.0)
+DEFAULT_XTC_THRESHOLD = os.getenv("DEFAULT_XTC_THRESHOLD", 0.0)
 DEFAULT_SEED = os.getenv("DEFAULT_SEED", 0)
 DEFAULT_MAX_TOKENS = os.getenv("DEFAULT_MAX_TOKENS", 8192)
 DEFAULT_BATCH_SIZE = os.getenv("DEFAULT_BATCH_SIZE", 32)
@@ -114,12 +116,28 @@ class MLX_LM:
             "temp": kwargs.get("temperature", DEFAULT_TEMPERATURE),
             "top_p": kwargs.get("top_p", DEFAULT_TOP_P),
             "top_k": kwargs.get("top_k", DEFAULT_TOP_K),
-            "min_p": kwargs.get("min_p", DEFAULT_MIN_P)
+            "min_p": kwargs.get("min_p", DEFAULT_MIN_P),
+            "xtc_probability": kwargs.get("xtc_probability", DEFAULT_XTC_PROBABILITY),
+            "xtc_threshold": kwargs.get("xtc_threshold", DEFAULT_XTC_THRESHOLD),
         }
+
+        # Add XTC special tokens (EOS and newline) when XTC is enabled
+        if sampler_kwargs["xtc_probability"] > 0:
+            sampler_kwargs["xtc_special_tokens"] = [
+                self.tokenizer.eos_token_id
+            ] + self.tokenizer.encode("\n")
 
         repetition_penalty = kwargs.get("repetition_penalty", 1.0)
         repetition_context_size = kwargs.get("repetition_context_size", 20)
-        logits_processors = make_logits_processors(repetition_penalty=repetition_penalty, repetition_context_size=repetition_context_size)
+        logit_bias = kwargs.get("logit_bias", None)
+        # Convert string keys to int if logit_bias is provided (OpenAI API uses string keys)
+        if logit_bias is not None:
+            logit_bias = {int(k): v for k, v in logit_bias.items()}
+        logits_processors = make_logits_processors(
+            logit_bias=logit_bias,
+            repetition_penalty=repetition_penalty,
+            repetition_context_size=repetition_context_size
+        )
         json_schema = kwargs.get("schema", None)
         if json_schema:
             logits_processors.append(


### PR DESCRIPTION
Sync sampler options with mlx-lm reference server. The mlx-lm library supports several sampling parameters that were not exposed through the OpenAI-compatible API.

New parameters added to ChatCompletionRequestBase:
- xtc_probability: XTC (eXclude Top Choices) sampling probability
- xtc_threshold: XTC sampling threshold
- logit_bias: Token likelihood modification (OpenAI-compatible)

Implementation details:
- Schema validates xtc_probability in [0,1], xtc_threshold in [0,0.5]
- logit_bias accepts string keys per OpenAI spec, converts to int
- XTC special tokens (EOS, newline) automatically configured when enabled
- logit_bias values validated in [-100, 100] range
- Added DEFAULT_XTC_PROBABILITY and DEFAULT_XTC_THRESHOLD env-var constants following existing pattern for sampler defaults