### PR TITLE
feat: make LRU prompt cache size configurable via CLI

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -197,6 +197,12 @@ def cli():
     is_flag=True,
     help="Enable debug mode for language models. Only works with language models (lm) and multimodal models.",
 )
+@click.option(
+    "--prompt-cache-size",
+    default=10,
+    type=int,
+    help="Maximum number of prompt KV cache entries to store. Only works with language models (lm). Default is 10.",
+)
 def launch(
     model_path,
     model_type,
@@ -221,6 +227,7 @@ def launch(
     trust_remote_code,
     chat_template_file,
     debug,
+    prompt_cache_size,
 ) -> None:
     """Start the FastAPI/Uvicorn server with the supplied flags.
 
@@ -253,6 +260,7 @@ def launch(
         trust_remote_code=trust_remote_code,
         chat_template_file=chat_template_file,
         debug=debug,
+        prompt_cache_size=prompt_cache_size,
     )
 
     asyncio.run(start(args))

--- a/app/config.py
+++ b/app/config.py
@@ -44,6 +44,7 @@ class MLXServerConfig:
     trust_remote_code: bool = False
     chat_template_file: str | None = None
     debug: bool = False
+    prompt_cache_size: int = 10
 
     # Used to capture raw CLI input before processing
     lora_paths_str: str | None = None

--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -21,7 +21,7 @@ class MLXLMHandler:
     Provides request queuing, metrics tracking, and robust error handling.
     """
 
-    def __init__(self, model_path: str, context_length: int | None = None, max_concurrency: int = 1, enable_auto_tool_choice: bool = False, tool_call_parser: str = None, reasoning_parser: str = None, message_converter: str = None, trust_remote_code: bool = False, chat_template_file: str = None, debug: bool = False):
+    def __init__(self, model_path: str, context_length: int | None = None, max_concurrency: int = 1, enable_auto_tool_choice: bool = False, tool_call_parser: str = None, reasoning_parser: str = None, message_converter: str = None, trust_remote_code: bool = False, chat_template_file: str = None, debug: bool = False, prompt_cache_size: int = 10):
         """
         Initialize the handler with the specified model path.
         
@@ -34,6 +34,7 @@ class MLXLMHandler:
             reasoning_parser (str): Name of the reasoning parser to use (qwen3, qwen3_next, glm4_moe, harmony, minimax, ...)
             trust_remote_code (bool): Enable trust_remote_code when loading models.
             chat_template_file (str): Path to a custom chat template file.
+            prompt_cache_size (int): Maximum number of prompt KV cache entries to store. Default is 10.
         """
         self.model_path = model_path
         self.model = MLX_LM(model_path, context_length, trust_remote_code=trust_remote_code, chat_template_file=chat_template_file)
@@ -46,7 +47,7 @@ class MLXLMHandler:
         self.debug = debug   
         self.reasoning_parser_name = reasoning_parser
         self.tool_parser_name = tool_call_parser
-        self.prompt_cache = LRUPromptCache()
+        self.prompt_cache = LRUPromptCache(max_size=prompt_cache_size)
         self.message_converter = MessageConverterManager.create_converter(message_converter)
         # Initialize request queue for text tasks
         self.request_queue = RequestQueue(max_concurrency=max_concurrency)

--- a/app/main.py
+++ b/app/main.py
@@ -69,6 +69,8 @@ def print_startup_banner(config_args):
             logger.info(f"🔧 Reasoning Parser: {config_args.reasoning_parser}")
         if config_args.message_converter:
             logger.info(f"🔧 Message Converter: {config_args.message_converter}")
+    if config_args.model_type == "lm":
+        logger.info(f"💾 Prompt Cache Size: {config_args.prompt_cache_size} entries")
     logger.info(f"📝 Log Level: {config_args.log_level}")
     if config_args.no_log_file:
         logger.info("📝 File Logging: Disabled")

--- a/app/server.py
+++ b/app/server.py
@@ -208,6 +208,7 @@ def create_lifespan(config_args: MLXServerConfig):
                     trust_remote_code=config_args.trust_remote_code,
                     chat_template_file=config_args.chat_template_file,
                     debug=config_args.debug,
+                    prompt_cache_size=config_args.prompt_cache_size,
                 )
             # Initialize queue
             await handler.initialize(


### PR DESCRIPTION
Problem: LRU cache size was hardcoded to 10 entries, preventing users from tuning cache behavior for different workloads.

Solution: Add --prompt-cache-size CLI option. The value threads through:
- CLI: New --prompt-cache-size option (default 10)
- Config: New MLXServerConfig.prompt_cache_size field
- Server: Pass config to MLXLMHandler initialization
- Handler: Pass prompt_cache_size to LRUPromptCache(max_size=...)
- Startup: Display cache size in logs

Usage: mlx-server launch --model-path <path> --prompt-cache-size 50