### PR TITLE
fix: preserve assistant messages with tool_calls when content is null

### DIFF
--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -582,7 +582,11 @@ class MLXLMHandler:
                 # Handle content that might be a list of dictionaries (multimodal format)
                 content = message.get("content", None)
                 if content is None:
-                    continue
+                    # Assistant messages with tool_calls have content: null — keep them
+                    if message.get("tool_calls"):
+                        message["content"] = ""
+                    else:
+                        continue
                 if isinstance(content, list):
                     # For LM models, extract only text content and concatenate
                     text_parts = []


### PR DESCRIPTION
When an assistant calls a tool, the OpenAI spec sends the message as {role: "assistant", content: null, tool_calls: [...]}. The previous code in _prepare_text_request did `if content is None: continue`, silently dropping the entire message.

This caused the chat template to raise:
  "Message has tool role, but there was no previous assistant
   message with a tool call!"

Fix: check for tool_calls before skipping null-content messages, and set content to "" so the template receives the assistant's tool call correctly.