### PR TITLE
Add openai dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "mlx-whisper>=0.4.3,<0.5",
   "mlx>=0.30.6",                        # Needed due to a typing issue in <0.30
   "numpy>=2.2.0,<2.4",
+  "openai>=2.21,<3",
   "openai-harmony>=0.0.8,<0.1",
   "outlines>=1.1.1,<1.2",
   "pillow>=10.4.0,<11.0",


### PR DESCRIPTION
This commit introduces the openai package with a version constraint of >=2.21,<3 to the dependencies in pyproject.toml, ensuring compatibility with the latest features and improvements.