### PR TITLE
feat: add Moonshot's partial mode extension

### DIFF
--- a/app/models/mlx_lm.py
+++ b/app/models/mlx_lm.py
@@ -105,10 +105,13 @@ class MLX_LM:
         return self.model_type
 
     def create_input_prompt(self, messages: List[Dict[str, str]], chat_template_kwargs: Dict[str, Any]) -> str:
+        use_partial = chat_template_kwargs.pop("_partial_mode", False)
+
         return self.tokenizer.apply_chat_template(
             messages,
-            tokenize = False,
-            add_generation_prompt=True,
+            tokenize=False,
+            add_generation_prompt=not use_partial,
+            continue_final_message=use_partial,
             **chat_template_kwargs,
         )
 

--- a/app/models/mlx_vlm.py
+++ b/app/models/mlx_vlm.py
@@ -84,6 +84,8 @@ class MLX_VLM:
         return make_prompt_cache(self.model.language_model, max_kv_size=self.context_length)
 
     def create_input_prompt(self, messages: List[Dict[str, str]], chat_template_kwargs: Dict[str, Any]) -> str:
+        chat_template_kwargs.pop("_partial_mode", None)
+
         return self.processor.apply_chat_template(
             messages,
             tokenize=False,

--- a/app/schemas/openai.py
+++ b/app/schemas/openai.py
@@ -208,11 +208,21 @@ class Message(OpenAIBaseModel):
     role: Literal["system", "user", "assistant", "tool"] = Field(
         ..., description="The role of the message sender."
     )
+    name: str | None = Field(
+        None,
+        description="An optional name for the participant. "
+        "Rendered into the chat template for models that support named messages.",
+    )
     reasoning_content: str | None = Field(None, description="The reasoning content, if any.")
     tool_calls: list[ChatCompletionMessageToolCall] | None = Field(
         None, description="List of tool calls, if any."
     )
     tool_call_id: str | None = Field(None, description="The ID of the tool call, if any.")
+    partial: bool = Field(
+        False,
+        description="When true on the final assistant message, the model continues "
+        "from this message instead of starting a new assistant turn (prefill / partial mode).",
+    )
 
 class ChatTemplateKwargs(OpenAIBaseModel):
     """Represents the arguments for a chat template."""


### PR DESCRIPTION
This PR implements support for Moonshot's "partial mode", an extension to the OpenAI chat completion API that enables API based message prefills and renaming of role anchors.

It should be noted that the actual code changes are very minor: the underlying infrastructure is already present in mlx_lm and the chat templates of Kimi K2 and K2.5. All these changes do are ensure that the "name" field gets passed through to mlx_lm without displaying a warning, and toggling from add_generation_prompt mode (currently hardcoded True) to continue_final_message mode based on the boolean value of the "partial" field.

Full disclosure: Moonshot has not publicly documented how "partial mode" is implemented on their API backend, but when you compare [their documentation](https://platform.moonshot.ai/docs/api/partial) to the model templates for [K2](https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/chat_template.jinja) and [K2.5](https://huggingface.co/moonshotai/Kimi-K2.5/blob/main/chat_template.jinja), it becomes pretty obvious what they're doing here.

A Claude generated summary is provided below for a more holistic explanation.

---

## Background: Moonshot's Partial Mode

Moonshot (the company behind Kimi K2 and K2.5) documents a feature called
**Partial Mode** in their API: when the final message in a chat completion
request is an assistant message with `"partial": true`, the model continues
from that message instead of starting a new assistant turn.

From [Moonshot's Partial Mode docs](https://platform.moonshot.ai/docs/api/partial):

> When using large language models, sometimes we want to guide the model's
> output by prefilling part of the response. In the Kimi large language model,
> we offer Partial Mode to achieve this. It helps us control the output format,
> guide the content, and maintain better consistency in role-playing scenarios.
> You just need to add `"partial": True` to the last message entry with the
> role of assistant to enable Partial Mode.

Moonshot documents two use cases:

### 1. JSON Mode via Prefill

```python
messages=[
    {"role": "system", "content": "Extract name, size, price, color as JSON."},
    {"role": "user", "content": "The SmartHome Mini costs 998 yuan..."},
    {"role": "assistant", "content": "{", "partial": True},
]
```

The model continues from `{` and produces valid JSON. The caller prepends the
prefill content to the response.

### 2. Roleplay Persona Consistency

```python
messages=[
    {"role": "system", "content": "You are Dr. Kelsier..."},
    {"role": "user", "content": "What do you think of Amiya?"},
    {"role": "assistant", "name": "Dr. Kelsier", "content": "", "partial": True},
]
```

Moonshot's docs explicitly say:

> We can also use the `"name":"Kelsier"` field on top of Partial Mode to better
> maintain the character's consistency. Here, the name field can be considered
> as part of the output prefix.

This is the key insight: the `name` field and `partial` mode compose. The name
provides **structural identity** (at the template framing level), while partial
provides **continuation** (the model generates as that named identity rather
than starting a generic "assistant" turn).

---

## How It Works at the Template Level

K2 and K2.5's chat templates render the `name` field into structural framing
tokens. In K2.5's template, the `set_roles` macro does:

```jinja
{%- set role_name = message.get('name') or message['role'] -%}
{%- if message['role'] == 'assistant' -%}
  <|im_assistant|>{{ role_name }}<|im_middle|>
```

So a message like `{"role": "assistant", "name": "Jarvis", "content": "Hello"}` renders as:

```
<|im_assistant|>Jarvis<|im_middle|>Hello<|im_end|>
```

While a plain `{"role": "assistant", "content": "Hello"}` renders as:

```
<|im_assistant|>assistant<|im_middle|>Hello<|im_end|>
```

The same applies to user and system messages — the name field replaces the
generic role label in the framing tokens.

### The generation prompt gap

Both K2 and K2.5 templates hardcode the generation prompt:

```jinja
{%- if add_generation_prompt -%}
<|im_assistant|>assistant<|im_middle|>
{%- endif -%}
```
When `add_generation_prompt=True`, the model always starts generating as
"assistant" — even if every prior assistant message in the conversation used a
custom name. This is the gap that partial mode solves.

### What partial mode produces

With the Moonshot roleplay example above, the desired token sequence is:

```
<|im_system|>system<|im_middle|>You are Dr. Kelsier...<|im_end|>
<|im_user|>user<|im_middle|>What do you think of Amiya?<|im_end|>
<|im_assistant|>Dr. Kelsier<|im_middle|>
```

Note: no `<|im_end|>` on the final message. The template renders the name into
the structural framing via its normal `set_roles` logic, and the server leaves
the message unclosed so the model continues from that point.

Without partial mode, the same request produces:

```
<|im_system|>system<|im_middle|>You are Dr. Kelsier...<|im_end|>
<|im_user|>user<|im_middle|>What do you think of Amiya?<|im_end|>
<|im_assistant|>assistant<|im_middle|>
```

The model starts generating as generic "assistant" instead of "Dr. Kelsier".

### More examples
**JSON prefill** — `{"role": "assistant", "content": "{", "partial": true}`:

```
...prior messages...
<|im_assistant|>assistant<|im_middle|>{
```

Model continues from `{` and produces structured JSON output.

**Named user messages** (no partial needed, already works):

```python
{"role": "user", "name": "Gandalf", "content": "You shall not pass!"}
```

Renders as:

```
<|im_user|>Gandalf<|im_middle|>You shall not pass!<|im_end|>
```

This works today because the `name` field already passes through
mlx-openai-server's pipeline (Pydantic `extra="allow"` preserves it). The only
issue is a spurious warning log because `name` isn't declared on the `Message`
schema.

---

## The Gap in mlx-openai-server

### `name` field passes through but triggers a warning

The `Message` class in `app/schemas/openai.py` (line 200) doesn't declare a
`name` field. Because `OpenAIBaseModel` uses `ConfigDict(extra="allow")`, the
field is accepted and preserved through `model_dump()`, but the model validator
(line 41) logs:

```
WARNING - The following fields were present in the request but ignored: {'name'}
```

The message is misleading — the field isn't actually ignored, it survives the
full pipeline and reaches the Jinja template. But the warning is noise.

### `add_generation_prompt` is hardcoded

In `app/models/mlx_lm.py` (line 107):

```python
def create_input_prompt(self, messages, chat_template_kwargs):
    return self.tokenizer.apply_chat_template(
        messages,
        tokenize=False,
        add_generation_prompt=True,
        **chat_template_kwargs,
    )
```

There is no way for a caller to request continuation of the final message
instead of starting a new assistant turn.

### HuggingFace already supports this

HuggingFace's `apply_chat_template` has a `continue_final_message` parameter
that does exactly what partial mode needs:

> The `continue_final_message` parameter controls whether the final message in
> the chat should be continued or not instead of starting a new one. It removes
> end of sequence tokens so that the model continues generation from the final
> message.
>
> — [HuggingFace Chat Templates docs](https://huggingface.co/docs/transformers/en/chat_templating)

HuggingFace's docs also note:

> You shouldn't use `add_generation_prompt` and `continue_final_message`
> together. The former adds tokens that start a new message, while the latter
> removes end of sequence tokens. Using them together returns an error.

### mlx_lm already uses this

mlx_lm's own `generate.py` implements the identical pattern for its
`--prefill-response` CLI feature (line 1424):

```python
has_prefill = args.prefill_response is not None
if has_prefill:
    messages.append({"role": "assistant", "content": args.prefill_response})
prompt = tokenizer.apply_chat_template(
    messages,
    tokenize=False,
    continue_final_message=has_prefill,
    add_generation_prompt=not has_prefill,
    **template_kwargs,
)
```

mlx_lm's tokenizer wrapper (`tokenizer_utils.py` line 314) passes all kwargs
through to HuggingFace's `apply_chat_template`, so `continue_final_message`
works without any changes to the tokenizer layer.

---

## References

- **Moonshot Partial Mode docs:** https://platform.moonshot.ai/docs/api/partial
- **HuggingFace `continue_final_message` docs:** https://huggingface.co/docs/transformers/en/chat_templating#continue_final_message
- **OpenAI Chat Completions API** (`name` field): https://platform.openai.com/docs/api-reference/chat/create
- **mlx_lm `--prefill-response`** (same pattern): `mlx_lm/generate.py` lines 1424-1433
- **K2-Instruct chat template** (name rendering): https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/chat_template.jinja
- **K2.5 chat template** (name rendering via `set_roles` macro): https://huggingface.co/moonshotai/Kimi-K2.5/blob/main/chat_template.jinja