### PR TITLE
fix: handle split reasoning/tool markers in streaming parsers

### DIFF
--- a/app/parsers/abstract_parser.py
+++ b/app/parsers/abstract_parser.py
@@ -12,7 +12,7 @@ class ReasoningParserState(Enum):
 
 class AbstractReasoningParser:
     """Abstract reasoning parser class that should not be used directly.
-    
+
     Provided properties and methods should be used in derived classes to parse
     reasoning content from model outputs.
     """
@@ -24,7 +24,7 @@ class AbstractReasoningParser:
         state: ReasoningParserState = ReasoningParserState.NORMAL,
     ) -> None:
         """Initialize the reasoning parser.
-        
+
         Parameters
         ----------
         reasoning_open : str
@@ -41,7 +41,7 @@ class AbstractReasoningParser:
 
     def get_reasoning_open(self) -> str:
         """Get the opening tag for reasoning content.
-        
+
         Returns
         -------
         str
@@ -51,7 +51,7 @@ class AbstractReasoningParser:
 
     def get_reasoning_close(self) -> str:
         """Get the closing tag for reasoning content.
-        
+
         Returns
         -------
         str
@@ -61,7 +61,7 @@ class AbstractReasoningParser:
 
     def needs_redacted_reasoning_prefix(self) -> bool:
         """Check if the reasoning parser needs a redacted reasoning prefix.
-        
+
         Returns
         -------
         bool
@@ -71,7 +71,7 @@ class AbstractReasoningParser:
 
     def has_special_parsing(self) -> bool:
         """Check if the reasoning parser has special parsing logic.
-        
+
         Returns
         -------
         bool
@@ -81,7 +81,7 @@ class AbstractReasoningParser:
 
     def respects_enable_thinking(self) -> bool:
         """Check if the reasoning parser respects the enable_thinking flag.
-        
+
         Returns
         -------
         bool
@@ -91,18 +91,18 @@ class AbstractReasoningParser:
 
     def extract_reasoning(self, model_output: str) -> dict[str, str] | None:
         """Extract reasoning content from complete model output.
-        
+
         Parameters
         ----------
         model_output : str
             Complete model output to parse.
-            
+
         Returns
         -------
         dict[str, str] | None
             Dictionary with 'reasoning' key containing extracted content,
             or None if no reasoning found.
-            
+
         Raises
         ------
         NotImplementedError
@@ -112,23 +112,21 @@ class AbstractReasoningParser:
             "AbstractReasoningParser.extract_reasoning has not been implemented!"
         )
 
-    def extract_reasoning_streaming(
-        self, chunk: str
-    ) -> tuple[dict[str, str] | str | None, bool]:
+    def extract_reasoning_streaming(self, chunk: str) -> tuple[dict[str, str] | str | None, bool]:
         """Extract reasoning content from streaming chunks.
-        
+
         Parameters
         ----------
         chunk : str
             Chunk of model output to process.
-            
+
         Returns
         -------
         tuple[dict[str, str] | str | None, bool]
             Tuple of (extracted_content, is_complete) where:
             - extracted_content: Reasoning dict, passthrough chunk, or None
             - is_complete: True if chunk should be sent, False if buffering
-            
+
         Raises
         ------
         NotImplementedError
@@ -147,9 +145,22 @@ class ToolParserState(Enum):
     FOUND_ARGUMENTS = "found_arguments"
 
 
+def _suffix_prefix_overlap(text: str, marker: str) -> int:
+    """Return longest suffix length of ``text`` matching marker prefix.
+
+    This is used to retain only the potentially incomplete marker tail across
+    chunk boundaries (for example ``<tool_`` followed by ``call>``).
+    """
+    max_overlap = min(len(text), len(marker) - 1)
+    for size in range(max_overlap, 0, -1):
+        if text.endswith(marker[:size]):
+            return size
+    return 0
+
+
 class AbstractToolParser:
     """Abstract tool parser class that should not be used directly.
-    
+
     Provided properties and methods should be used in derived classes to parse
     tool calls from model outputs.
     """
@@ -161,7 +172,7 @@ class AbstractToolParser:
         state: ToolParserState = ToolParserState.NORMAL,
     ) -> None:
         """Initialize the tool parser.
-        
+
         Parameters
         ----------
         tool_open : str
@@ -178,7 +189,7 @@ class AbstractToolParser:
 
     def get_tool_open(self) -> str:
         """Get the opening tag for tool calls.
-        
+
         Returns
         -------
         str
@@ -188,7 +199,7 @@ class AbstractToolParser:
 
     def get_tool_close(self) -> str:
         """Get the closing tag for tool calls.
-        
+
         Returns
         -------
         str
@@ -198,40 +209,36 @@ class AbstractToolParser:
 
     def extract_tool_calls(self, model_output: str) -> dict[str, list] | None:
         """Extract tool calls from complete model output.
-        
+
         Parameters
         ----------
         model_output : str
             Complete model output to parse.
-            
+
         Returns
         -------
         dict[str, list] | None
             Dictionary with 'tool_calls' key containing list of tool calls,
             or None if no tool calls found.
-            
+
         Raises
         ------
         NotImplementedError
             This method must be implemented by derived classes.
         """
-        raise NotImplementedError(
-            "AbstractToolParser.extract_tool_calls has not been implemented!"
-        )
+        raise NotImplementedError("AbstractToolParser.extract_tool_calls has not been implemented!")
 
-    def extract_tool_calls_streaming(
-        self, chunk: str
-    ) -> tuple[dict[str, list] | str | None, bool]:
+    def extract_tool_calls_streaming(self, chunk: str) -> tuple[dict[str, list] | str | None, bool]:
         """Extract tool calls from streaming chunks.
-        
+
         Default implementation that buffers content between tool_open and tool_close
         tags. Subclasses can override this for custom streaming behavior.
-        
+
         Parameters
         ----------
         chunk : str
             Chunk of model output to process.
-            
+
         Returns
         -------
         tuple[dict[str, list] | str | None, bool]
@@ -239,28 +246,51 @@ class AbstractToolParser:
             - extracted_content: Tool calls dict, passthrough chunk, or None
             - is_complete: True if chunk should be sent, False if buffering
         """
-        if self.tool_open in chunk:
-            self.state = ToolParserState.FOUND_PREFIX
+        if self.state == ToolParserState.NORMAL:
+            combined = self.buffer + chunk
+            open_idx = combined.find(self.tool_open)
+            if open_idx >= 0:
+                self.state = ToolParserState.FOUND_PREFIX
+                passthrough = combined[:open_idx]
+                self.buffer = combined[open_idx:]
 
-            if self.tool_close in chunk:
-                self.buffer += chunk
-                result = self.extract_tool_calls(self.buffer)
-                self.buffer = ""
-                self.state = ToolParserState.NORMAL
-                return result, True
-            else:
-                self.buffer += chunk
+                if self.tool_close in self.buffer:
+                    result = self.extract_tool_calls(self.buffer)
+                    self.buffer = ""
+                    self.state = ToolParserState.NORMAL
+                    if passthrough:
+                        merged = dict(result) if isinstance(result, dict) else {}
+                        merged_content = merged.get("content")
+                        if merged_content:
+                            merged["content"] = f"{passthrough}{merged_content}"
+                        else:
+                            merged["content"] = passthrough
+                        return merged, True
+                    return result, True
+
+                if passthrough:
+                    return {"content": passthrough}, False
                 return None, False
 
-        if self.state == ToolParserState.FOUND_PREFIX:
-            if self.tool_close in chunk:
-                self.buffer += chunk
-                result = self.extract_tool_calls(self.buffer)
-                self.buffer = ""
-                self.state = ToolParserState.NORMAL
-                return result, True
+            overlap = _suffix_prefix_overlap(combined, self.tool_open)
+            if overlap > 0:
+                passthrough = combined[:-overlap]
+                self.buffer = combined[-overlap:]
             else:
-                self.buffer += chunk
-                return None, False
+                passthrough = combined
+                self.buffer = ""
 
-        return {"content": chunk}, False
+            if passthrough:
+                return {"content": passthrough}, False
+            return None, False
+
+        combined = self.buffer + chunk
+        if self.tool_close in combined:
+            self.buffer = combined
+            result = self.extract_tool_calls(self.buffer)
+            self.buffer = ""
+            self.state = ToolParserState.NORMAL
+            return result, True
+
+        self.buffer = combined
+        return None, False

--- a/tests/parsers/test_streaming_tag_split_boundaries.py
+++ b/tests/parsers/test_streaming_tag_split_boundaries.py
@@ -1,0 +1,88 @@
+"""Regression tests for streaming parser behavior across chunk boundaries."""
+
+from __future__ import annotations
+
+import json
+
+from app.parsers.function_parameter import FunctionParameterToolParser
+from app.parsers.qwen3_moe import Qwen3MoEReasoningParser
+
+
+def test_qwen3_reasoning_parser_handles_split_reasoning_close_tag() -> None:
+    """Reasoning parsing should complete even when ``</think>`` is split across chunks."""
+    parser = Qwen3MoEReasoningParser()
+
+    # Mirror handler behavior for step_35/qwen3_moe reasoning parsers:
+    # first chunk is prefixed with `<think>` when the model omits it.
+    first_chunk = "<think>" + "I should call a tool now.</th"
+    second_chunk = "ink><tool_call>"
+
+    first_result, first_complete = parser.extract_reasoning_streaming(first_chunk)
+    second_result, second_complete = parser.extract_reasoning_streaming(second_chunk)
+
+    assert first_result is not None
+    assert first_complete is False
+    assert second_result is not None
+    assert second_complete is True
+    assert second_result.get("after_reasoning_close_content") == "<tool_call>"
+
+
+def test_function_parameter_tool_parser_handles_split_tool_open_tag() -> None:
+    """Tool parsing should work when ``<tool_call>`` is split across chunks."""
+    parser = FunctionParameterToolParser()
+
+    chunks = [
+        "Prefix text <tool_",
+        (
+            "call>\n"
+            "<function=get_weather>\n"
+            '<parameter=city>"NYC"</parameter>\n'
+            "</function>\n"
+            "</tool_call>"
+        ),
+    ]
+
+    parsed_outputs: list[dict[str, object]] = []
+    for chunk in chunks:
+        parsed, _is_complete = parser.extract_tool_calls_streaming(chunk)
+        if isinstance(parsed, dict):
+            parsed_outputs.append(parsed)
+
+    tool_payload = next((item for item in parsed_outputs if "tool_calls" in item), None)
+    assert tool_payload is not None
+
+    tool_calls = tool_payload["tool_calls"]
+    assert isinstance(tool_calls, list)
+    assert len(tool_calls) == 1
+    tool_call = tool_calls[0]
+    assert tool_call["name"] == "get_weather"
+    assert json.loads(tool_call["arguments"]) == {"city": "NYC"}
+
+
+def test_function_parameter_tool_parser_preserves_leading_text_before_tool_open() -> None:
+    """Parser should emit text that appears before a full ``<tool_call>`` marker."""
+    parser = FunctionParameterToolParser()
+
+    chunks = [
+        "Lead text <tool_call>\n<function=get_weather>",
+        '\n<parameter=city>"NYC"</parameter>\n</function>\n</tool_call>',
+    ]
+
+    parsed_outputs: list[dict[str, object]] = []
+    for chunk in chunks:
+        parsed, _is_complete = parser.extract_tool_calls_streaming(chunk)
+        if isinstance(parsed, dict):
+            parsed_outputs.append(parsed)
+
+    content_payload = next((item for item in parsed_outputs if item.get("content")), None)
+    assert content_payload is not None
+    assert content_payload["content"] == "Lead text "
+
+    tool_payload = next((item for item in parsed_outputs if "tool_calls" in item), None)
+    assert tool_payload is not None
+    tool_calls = tool_payload["tool_calls"]
+    assert isinstance(tool_calls, list)
+    assert len(tool_calls) == 1
+    tool_call = tool_calls[0]
+    assert tool_call["name"] == "get_weather"
+    assert json.loads(tool_call["arguments"]) == {"city": "NYC"}


### PR DESCRIPTION
## PR Description
This PR fixes intermittent streaming parse failures caused by chunk-boundary splits in parser markers for the `step_35` path (`Qwen3MoEReasoningParser` + `FunctionParameterToolParser`).

When model output split tags like `</think>` or `<tool_call>` across chunks, the previous streaming logic could miss state transitions and either:

- never complete reasoning parsing, or
- fail to detect tool calls and emit raw text instead.

## What Changed

- Updated tool streaming parser logic to preserve partial open-marker suffixes across chunks and resume correctly on the next chunk.
- Updated reasoning streaming parser logic to handle split `</think>` close tags across chunk boundaries.
- Preserved leading passthrough text before `<tool_call>` when tool call starts in the same chunk.

Files:

- [app/parsers/abstract_parser.py](app://-/index.html?hostId=local#)
- [app/parsers/hermes.py](app://-/index.html?hostId=local#)
- [tests/parsers/test_streaming_tag_split_boundaries.py](app://-/index.html?hostId=local#)

## Tests Added
New regression coverage in:

[tests/parsers/test_streaming_tag_split_boundaries.py](app://-/index.html?hostId=local#)

Tests included:

1. split `</think>` across chunks completes reasoning parse and surfaces after_reasoning_close_content
2. split `<tool_call>` open tag across chunks still parses function call
3. leading text before full `<tool_call>` is preserved as passthrough content

These are non-vacuous because they assert concrete parser state/output invariants that previously failed under real chunk-splitting patterns.

### Validation
Commands run:

- `./.venv/bin/python -m pytest tests/parsers/test_streaming_tag_split_boundaries.py tests/parsers/test_hermes.py tests/parsers/test_functiongemma.py tests/parsers/test_glm4_moe.py -q`

Result:

`6 passed`

### Scope Notes

- This PR is intentionally parser-focused.
- Endpoint-level chat streaming delta conformance (tool_calls index/id behavior) is tracked as follow-up work on a separate branch/thread to keep scope and review risk contained.