### PR TITLE
fix(stream): preserve tool_call id stability across deltas

### DIFF
--- a/tests/test_stream_tool_call_ids.py
+++ b/tests/test_stream_tool_call_ids.py
@@ -1,0 +1,100 @@
+"""Regression tests for streaming tool-call ID behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator, Iterable
+import json
+from typing import Any
+import unittest
+
+from app.api.endpoints import handle_stream_response
+
+
+class StreamToolCallIdTests(unittest.TestCase):
+    """Validate tool-call IDs and indices in chat-completions streaming mode."""
+
+    @staticmethod
+    async def _chunk_generator(
+        chunks: Iterable[str | dict[str, Any]],
+    ) -> AsyncGenerator[str | dict[str, Any], None]:
+        """Yield chunks that emulate handler streaming output."""
+        for chunk in chunks:
+            yield chunk
+
+    async def _collect_stream_payloads(
+        self,
+        chunks: Iterable[str | dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Collect JSON payloads emitted by the SSE stream wrapper."""
+        payloads: list[dict[str, Any]] = []
+        async for event in handle_stream_response(
+            self._chunk_generator(chunks),
+            model="test-model",
+        ):
+            if not event.startswith("data: "):
+                continue
+            serialized = event[len("data: ") :].strip()
+            if serialized == "[DONE]":
+                continue
+            payloads.append(json.loads(serialized))
+        return payloads
+
+    @staticmethod
+    def _extract_tool_delta_entries(payloads: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Extract ``delta.tool_calls[0]`` entries from streamed payloads."""
+        tool_entries: list[dict[str, Any]] = []
+        for payload in payloads:
+            choices = payload.get("choices", [])
+            if not choices:
+                continue
+            delta = choices[0].get("delta") or {}
+            tool_calls = delta.get("tool_calls") or []
+            if tool_calls:
+                tool_entries.append(tool_calls[0])
+        return tool_entries
+
+    def test_tool_call_id_is_stable_for_same_streamed_tool_call(self) -> None:
+        """Tool-call ID must remain constant across deltas for one tool index."""
+        chunks: list[dict[str, str]] = [
+            {"name": "get_weather"},
+            {"arguments": '{"city":"'},
+            {"arguments": 'Boston"}'},
+        ]
+
+        payloads = asyncio.run(self._collect_stream_payloads(chunks))
+        tool_entries = self._extract_tool_delta_entries(payloads)
+
+        assert len(tool_entries) == 3
+        assert [entry["index"] for entry in tool_entries] == [0, 0, 0]
+
+        tool_ids = [entry["id"] for entry in tool_entries]
+        assert len(set(tool_ids)) == 1, (
+            "Expected one stable tool_call id for all deltas of index 0."
+        )
+
+    def test_tool_call_index_and_id_advance_with_new_calls(self) -> None:
+        """A new tool call should increment index and use a new stable ID."""
+        chunks: list[dict[str, str]] = [
+            {"name": "get_weather"},
+            {"arguments": '{"city":"Boston"}'},
+            {"name": "get_time"},
+            {"arguments": '{"timezone":"UTC"}'},
+        ]
+
+        payloads = asyncio.run(self._collect_stream_payloads(chunks))
+        tool_entries = self._extract_tool_delta_entries(payloads)
+
+        assert len(tool_entries) == 4
+        assert [entry["index"] for entry in tool_entries] == [0, 0, 1, 1]
+
+        tool_ids = [entry["id"] for entry in tool_entries]
+        assert tool_ids[0] == tool_ids[1], "Expected index 0 deltas to reuse the same tool_call id."
+        assert tool_ids[2] == tool_ids[3], "Expected index 1 deltas to reuse the same tool_call id."
+        assert tool_ids[0] != tool_ids[2], (
+            "Expected different tool calls to have different tool_call ids."
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary

This PR fixes non-conformant streaming tool-call delta behavior in the chat completions endpoint. Previously, when streaming multiple tool calls, the `index` and `id` fields were not correctly managed according to the OpenAI specification, causing client compatibility issues.

The fix ensures that:
- Each tool call receives a unique, stable `id` that persists across all deltas for that call
- The `index` properly increments when a new tool call starts (0, 1, 2, ...)
- All deltas belonging to the same tool call share the same `index` and `id`
- Different tool calls have distinct `id` values

This is a follow-up to the split-tag parser robustness fix (commit 09af02e) and focuses solely on the endpoint-level SSE chunk formatting behavior.

### Changes

**`app/api/endpoints.py`** - Modified `handle_stream_response`:
- Added `tool_call_ids: dict[int, str]` to track stable IDs per tool call index
- Logic to assign a new ID only when a new tool call (by index) is first encountered
- Reuse the stored ID for all subsequent deltas of the same tool call
- Maintains correct index incrementing on new tool calls

**`tests/test_stream_tool_call_ids.py`** - New regression test suite:
- `test_tool_call_id_is_stable_for_same_streamed_tool_call`: Verifies that a single tool call's ID remains constant across multiple deltas (name + multi-chunk arguments)
- `test_tool_call_index_and_id_advance_with_new_calls`: Verifies that multiple tool calls get sequential indices and distinct stable IDs

### Testing

Run the focused test suite:
```bash
./.venv/bin/python -m pytest tests/test_stream_tool_call_ids.py -q
```

Expected output: `2 passed`

### Specification Reference

OpenAI API streaming format for tool calls:
- Each tool call delta includes `index` (integer position) and `id` (stable identifier)
- The `id` must remain consistent across all deltas that belong to the same tool call
- When multiple tool calls are streamed, `index` should increment for each new call
- See: https://platform.openai.com/docs/api-reference/chat/streaming

### Impact

- **No breaking changes**: Only internal behavior correction
- **No parser modifications**: Changes isolated to endpoint formatting logic
- **Full backward compatibility**: The fix aligns output with OpenAI spec, improving interoperability with OpenAI-compatible clients