### PR TITLE
feat: add DEFAULT_MIN_P environment variable support for chat completions

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -309,6 +309,8 @@ def refine_chat_completion_request(
         request.top_p = _parse_env_float("DEFAULT_TOP_P")
     if request.top_k is None:
         request.top_k = _parse_env_int("DEFAULT_TOP_K")
+    if request.min_p is None:
+        request.min_p = _parse_env_float("DEFAULT_MIN_P")
     if request.seed is None:
         request.seed = _parse_env_int("DEFAULT_SEED")
     if request.repetition_penalty is None:

--- a/tests/test_chat_completions_defaults.py
+++ b/tests/test_chat_completions_defaults.py
@@ -1,0 +1,66 @@
+"""Unit tests for chat-completions env defaulting helpers."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+
+import pytest
+
+from app.schemas.openai import ChatCompletionRequest, Message
+
+
+def _load_refine_chat_completion_request() -> object:
+    """Import refine function with lightweight handler stubs."""
+    fake_lm_module = types.ModuleType("app.handler.mlx_lm")
+    fake_lm_module.MLXLMHandler = object
+
+    fake_vlm_module = types.ModuleType("app.handler.mlx_vlm")
+    fake_vlm_module.MLXVLMHandler = object
+
+    module_names = [
+        "app.handler.mlx_lm",
+        "app.handler.mlx_vlm",
+        "app.api.endpoints",
+    ]
+    original_modules: dict[str, types.ModuleType | None] = {
+        name: sys.modules.get(name) for name in module_names
+    }
+
+    try:
+        sys.modules["app.handler.mlx_lm"] = fake_lm_module
+        sys.modules["app.handler.mlx_vlm"] = fake_vlm_module
+        sys.modules.pop("app.api.endpoints", None)
+        endpoints_module = importlib.import_module("app.api.endpoints")
+        return endpoints_module.refine_chat_completion_request
+    finally:
+        sys.modules.pop("app.api.endpoints", None)
+        for name, module in original_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def test_refine_chat_completion_request_sets_min_p_from_env_when_missing() -> None:
+    """refine_chat_completion_request should default min_p from DEFAULT_MIN_P."""
+    refine_chat_completion_request = _load_refine_chat_completion_request()
+
+    previous = os.environ.get("DEFAULT_MIN_P")
+    os.environ["DEFAULT_MIN_P"] = "0.123"
+    try:
+        request = ChatCompletionRequest(
+            model="local-text-model",
+            messages=[Message(role="user", content="hi")],
+            min_p=None,
+        )
+
+        refined = refine_chat_completion_request(request)
+        assert refined.min_p == pytest.approx(0.123)
+    finally:
+        if previous is None:
+            os.environ.pop("DEFAULT_MIN_P", None)
+        else:
+            os.environ["DEFAULT_MIN_P"] = previous


### PR DESCRIPTION
Summary
This PR adds support for a `DEFAULT_MIN_P` environment variable that sets a default value for the `min_p` parameter in chat completion requests when it is not explicitly provided.

### Changes
- **`app/api/endpoints.py`**: Added logic in `refine_chat_completion_request` to default `request.min_p` from `DEFAULT_MIN_P` env var when `min_p` is `None`. Follows the same pattern used for `top_p`, `top_k`, `seed`, etc.
- **`tests/test_chat_completions_defaults.py`**: New test module with `test_refine_chat_completion_request_sets_min_p_from_env_when_missing` that verifies the environment variable defaulting behavior.

### Why
The `min_p` parameter (nucleus sampling minimum probability threshold) is already part of the `ChatCompletionRequest` schema and used during generation. However, there was no way to set a default via environment variable, unlike other generation parameters. This change makes the API more flexible and consistent with the existing defaulting mechanism.

### Testing
- Added isolated unit test that loads the `refine_chat_completion_request` function without importing heavy handler modules.
- Test verifies that when `min_p` is `None` and `DEFAULT_MIN_P` is set, the request is refined to use that value.
- Test cleans up environment variables properly to avoid leakage.

### Impact
- **Low risk**: Small, localized change; no breaking changes.
- **No migrations**: Existing behavior unchanged when `min_p` is provided or env var unset.
- **Performance**: No impact.

### Review notes
- The implementation is a 2-line addition mirroring the existing pattern for other defaults.
- The test is self-contained and focuses solely on this behavior.

---

Feel free to adjust any part of that. If you want me to open the PR on GitHub as well, I can do that (but that would require additional setup with GitHub CLI or API). Let me know!