### PR TITLE
fix: persist prompt cache when streaming is cancelled

### DIFF
--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -76,11 +76,11 @@ class MLXLMHandler:
         )
         self.model_created = int(time.time())  # Store creation time when model is loaded
         self.model_type = self.model.get_model_type()
-        
+
         # Store parser configuration
         self.enable_auto_tool_choice = enable_auto_tool_choice
         # Debug mode
-        self.debug = debug   
+        self.debug = debug
         self.reasoning_parser_name = reasoning_parser
         self.tool_parser_name = tool_call_parser
         self.prompt_cache = LRUPromptCache(max_size=prompt_cache_size)
@@ -105,7 +105,7 @@ class MLXLMHandler:
         except Exception as e:
             logger.error(f"Error getting models: {str(e)}")
             return []
-    
+
     async def initialize(self, queue_config: Optional[Dict[str, Any]] = None) -> None:
         """Initialize the handler and start the inference worker.
 
@@ -137,7 +137,7 @@ class MLXLMHandler:
             logger.info("Message converter is enabled, converting messages...")
             messages = self.message_converter.convert_messages(messages)
             logger.info("Messages converted successfully")
-        
+
         logger.info("Filtering out None values from messages...")
         for message in messages:
             cleaned_message = {k: v for k, v in message.items() if v is not None}
@@ -156,6 +156,10 @@ class MLXLMHandler:
         Yields:
             str or dict: Response chunks (str) followed by usage info (dict) at the end.
         """
+        cache: list[Any] | None = None
+        cache_key: list[int] | None = None
+        cache_inserted = False
+
         try:
             chat_messages, model_params = await self._prepare_text_request(request)
 
@@ -188,7 +192,7 @@ class MLXLMHandler:
             if self.debug:
                 log_debug_cache_stats(total_input_tokens, total_remaining_tokens)
 
-                
+
             enable_thinking = chat_template_kwargs.get("enable_thinking", True)
 
             # Create parsers using ParserManager
@@ -217,7 +221,7 @@ class MLXLMHandler:
                 "prompt_progress_callback": prompt_progress_callback,
                 **model_params
             }
-            
+
             if self.debug:
                 log_debug_request(request_data)
                 request_data["verbose"] = True
@@ -239,7 +243,7 @@ class MLXLMHandler:
             final_chunk = None
             is_first_chunk = True
             raw_text = "" # only use for debugging
-            
+
             # Handle unified parser streaming
             if parsers_result.is_unified:
                 unified_parser = parsers_result.unified_parser
@@ -280,7 +284,7 @@ class MLXLMHandler:
                 # Handle separate parsers streaming
                 reasoning_parser = parsers_result.reasoning_parser
                 tool_parser = parsers_result.tool_parser
-                
+
                 async for chunk in response_generator:
                     if chunk is None:
                         continue
@@ -321,6 +325,7 @@ class MLXLMHandler:
 
             total_tokens = final_chunk.prompt_tokens + final_chunk.generation_tokens
             self.prompt_cache.insert_cache(cache_key, cache)
+            cache_inserted = True
 
             if self.debug:
                 log_debug_raw_text_response(raw_text)
@@ -347,10 +352,18 @@ class MLXLMHandler:
             logger.error("Too many requests. Service is at capacity.")
             content = create_error_response("Too many requests. Service is at capacity.", "rate_limit_exceeded", HTTPStatus.TOO_MANY_REQUESTS)
             raise HTTPException(status_code=429, detail=content)
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             logger.error(f"Error in text stream generation: {str(e)}")
             content = create_error_response(f"Failed to generate text stream: {str(e)}", "server_error", HTTPStatus.INTERNAL_SERVER_ERROR)
             raise HTTPException(status_code=500, detail=content)
+        finally:
+            if cache is not None and cache_key is not None and not cache_inserted:
+                try:
+                    self.prompt_cache.insert_cache(cache_key, cache)
+                except Exception as cache_error:
+                    logger.warning(f"Failed to persist prompt cache during stream finalization: {cache_error}")
 
     async def generate_text_response(self, request: ChatCompletionRequest) -> Dict[str, Any]:
         """
@@ -393,7 +406,7 @@ class MLXLMHandler:
 
             if self.debug:
                 log_debug_cache_stats(total_input_tokens, total_remaining_tokens)
-            
+
             prompt_progress_callback = make_prompt_progress_callback() if self.debug else None
 
             request_data = {
@@ -416,7 +429,7 @@ class MLXLMHandler:
                 stream=False,
                 **request_data,
             )
-            
+
             # Create parsers using ParserManager
             parsers_result = ParserManager.create_parsers(
                 reasoning_parser_name=self.reasoning_parser_name,
@@ -502,7 +515,7 @@ class MLXLMHandler:
             )
 
             return {"response": parsed_response, "usage": usage}
-                        
+
         except asyncio.QueueFull:
             logger.error("Too many requests. Service is at capacity.")
             content = create_error_response("Too many requests. Service is at capacity.", "rate_limit_exceeded", HTTPStatus.TOO_MANY_REQUESTS)
@@ -511,7 +524,7 @@ class MLXLMHandler:
             logger.error(f"Error in text response generation: {str(e)}")
             content = create_error_response(f"Failed to generate text response: {str(e)}", "server_error", HTTPStatus.INTERNAL_SERVER_ERROR)
             raise HTTPException(status_code=500, detail=content)
-        
+
 
     async def get_queue_stats(self) -> Dict[str, Any]:
         """Get statistics from the inference worker.
@@ -524,7 +537,7 @@ class MLXLMHandler:
         return {
             "queue_stats": self.inference_worker.get_stats(),
         }
-        
+
     async def cleanup(self) -> None:
         """Cleanup resources and stop the inference worker before shutdown.
 
@@ -571,12 +584,12 @@ class MLXLMHandler:
                 response_format = request_dict.pop("response_format")
                 if response_format.get("type") == "json_schema":
                     request_dict["schema"] = response_format.get("json_schema", {}).get("schema")
-            
+
             # Format chat messages and merge system messages into index 0
             chat_messages = []
             system_messages = []
             non_system_messages = []
-            
+
             for message in request_dict.pop("messages", []):
                 # Handle content that might be a list of dictionaries (multimodal format)
                 content = message.get("content")
@@ -593,26 +606,26 @@ class MLXLMHandler:
                         if isinstance(item, dict) and item.get("type") == "text" and item.get("text"):
                             text_parts.append(item["text"])
                     content = "\n".join(text_parts) if text_parts else ""
-                
-                message["content"] = content                
+
+                message["content"] = content
                 # Separate system messages from other messages
                 if message.get("role") == "system":
                     system_messages.append(message)
                 else:
                     non_system_messages.append(message)
-            
+
             # If there are system messages, merge them into a single system message at index 0
             if system_messages:
                 # Combine all system message contents
                 combined_system_content = "\n\n".join([msg["content"] for msg in system_messages if msg.get("content")])
-                
+
                 # Create merged system message using the first system message as template
                 merged_system_message = system_messages[0].copy()
                 merged_system_message["content"] = combined_system_content
-                
+
                 # Add merged system message at index 0
                 chat_messages.append(merged_system_message)
-            
+
             # Add all non-system messages after the merged system message
             chat_messages.extend(non_system_messages)
 
@@ -632,7 +645,7 @@ class MLXLMHandler:
                 chat_template_kwargs["_partial_mode"] = True
 
             return chat_messages, request_dict
-        
+
         except Exception as e:
             logger.error(f"Failed to prepare text request: {str(e)}")
             content = create_error_response(f"Failed to process request: {str(e)}", "bad_request", HTTPStatus.BAD_REQUEST)

--- a/tests/test_prompt_cache_cancellation.py
+++ b/tests/test_prompt_cache_cancellation.py
@@ -1,0 +1,330 @@
+"""Tests for prompt cache insertion behavior on cancellation and errors."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from contextlib import suppress
+import importlib
+from pathlib import Path
+import sys
+import types
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+
+def _install_fake_mlx_cache_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a lightweight mlx_lm.models.cache stub used by prompt cache imports."""
+
+    fake_mlx_lm = types.ModuleType("mlx_lm")
+    fake_models = types.ModuleType("mlx_lm.models")
+    fake_cache = types.ModuleType("mlx_lm.models.cache")
+
+    def can_trim_prompt_cache(cache: list[Any]) -> bool:
+        return bool(cache)
+
+    def trim_prompt_cache(cache: list[Any], num_tokens: int) -> int:
+        return min(num_tokens, len(cache))
+
+    fake_cache.can_trim_prompt_cache = can_trim_prompt_cache
+    fake_cache.trim_prompt_cache = trim_prompt_cache
+    fake_models.cache = fake_cache
+    fake_mlx_lm.models = fake_models
+
+    monkeypatch.setitem(sys.modules, "mlx_lm", fake_mlx_lm)
+    monkeypatch.setitem(sys.modules, "mlx_lm.models", fake_models)
+    monkeypatch.setitem(sys.modules, "mlx_lm.models.cache", fake_cache)
+
+
+def _load_handler_class(monkeypatch: pytest.MonkeyPatch) -> type[Any]:
+    """Import ``MLXLMHandler`` while stubbing MLX-backed imports for CI safety."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+
+    # Bypass app/handler/__init__.py eager imports (which pull MLX-backed modules).
+    fake_handler_pkg = types.ModuleType("app.handler")
+    fake_handler_pkg.__path__ = [str(repo_root / "app" / "handler")]
+    monkeypatch.setitem(sys.modules, "app.handler", fake_handler_pkg)
+
+    # Stub model wrapper imported by app.handler.mlx_lm.
+    fake_mlx_lm_model = types.ModuleType("app.models.mlx_lm")
+
+    class _FakeMLXLM:
+        pass
+
+    fake_mlx_lm_model.MLX_LM = _FakeMLXLM
+    monkeypatch.setitem(sys.modules, "app.models.mlx_lm", fake_mlx_lm_model)
+
+    _install_fake_mlx_cache_module(monkeypatch)
+    sys.modules.pop("app.handler.mlx_lm", None)
+    handler_module = importlib.import_module("app.handler.mlx_lm")
+    handler_module = importlib.reload(handler_module)
+    return handler_module.MLXLMHandler
+
+
+@pytest.mark.asyncio
+async def test_prompt_cache_inserted_on_stream_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Verify that the prompt cache is inserted when the streaming generator
+    is cancelled (i.e., closed via GeneratorExit) before completion.
+
+    """
+    # Mock dependencies
+    mock_model = Mock()
+    mock_model.create_input_prompt.return_value = "prompt"
+    mock_model.encode_prompt.return_value = [1, 2, 3]
+    mock_model.create_prompt_cache.return_value = Mock(name="cache_obj")
+
+    mock_inference_worker = Mock()
+
+    async def mock_response_gen() -> AsyncGenerator[Mock, None]:
+        chunk = Mock()
+        chunk.text = "Hello"
+        chunk.token = 4
+        yield chunk
+
+    mock_inference_worker.submit_stream = Mock(side_effect=lambda *args, **kwargs: mock_response_gen())
+
+    mock_prompt_cache = Mock()
+    mock_prompt_cache.fetch_nearest_cache.return_value = (Mock(name="cache_obj"), [])
+
+    mlx_lm_handler = _load_handler_class(monkeypatch)
+    handler = mlx_lm_handler.__new__(mlx_lm_handler)
+    handler.model = mock_model
+    handler.inference_worker = mock_inference_worker
+    handler.prompt_cache = mock_prompt_cache
+    handler.reasoning_parser_name = ""
+    handler.tool_parser_name = ""
+    handler.debug = False
+    handler.model_path = "/fake"
+    handler.model_created = 12345
+    handler.model_type = "text"
+    handler.enable_auto_tool_choice = False
+    handler.message_converter = Mock()
+
+    # Mock internal methods
+    handler._prepare_text_request = AsyncMock(return_value=([], {}))
+    handler.refine_messages = Mock(return_value=[])
+
+    # Mock ParserManager to avoid parser logic
+    mock_parsers_result = Mock()
+    mock_parsers_result.is_unified = False
+    mock_parsers_result.reasoning_parser = None
+    mock_parsers_result.tool_parser = None
+    with patch('app.handler.mlx_lm.ParserManager.create_parsers', return_value=mock_parsers_result):
+        fake_request = Mock()
+        gen = handler.generate_text_stream(fake_request)
+        try:
+            async for _ in gen:
+                break
+        finally:
+            # Explicitly close the generator to trigger GeneratorExit.
+            await gen.aclose()
+
+        # After cancellation, the cache should be inserted exactly once.
+        mock_prompt_cache.insert_cache.assert_called_once()
+        # Verify the cache_key includes the initial input_ids and the token from the chunk.
+        call_args = mock_prompt_cache.insert_cache.call_args
+        inserted_key = call_args[0][0]
+        inserted_cache = call_args[0][1]
+        assert inserted_key == [1, 2, 3, 4]
+        assert inserted_cache is mock_prompt_cache.fetch_nearest_cache.return_value[0]
+
+
+@pytest.mark.asyncio
+async def test_prompt_cache_inserted_on_normal_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that the prompt cache is inserted when the streaming generator completes normally."""
+    mock_model = Mock()
+    mock_model.create_input_prompt.return_value = "prompt"
+    input_ids = [1, 2, 3]
+    mock_model.encode_prompt.return_value = input_ids
+    mock_model.create_prompt_cache.return_value = Mock(name="cache_obj")
+
+    mock_inference_worker = Mock()
+
+    async def mock_response_gen() -> AsyncGenerator[Mock, None]:
+        for token in [4, 5, 6]:
+            chunk = Mock()
+            chunk.text = f"Token {token}"
+            chunk.token = token
+            if token == 6:
+                chunk.prompt_tokens = 10
+                chunk.generation_tokens = 20
+            yield chunk
+
+    mock_inference_worker.submit_stream = Mock(side_effect=lambda *args, **kwargs: mock_response_gen())
+
+    mock_prompt_cache = Mock()
+    mock_prompt_cache.fetch_nearest_cache.return_value = (Mock(name="cache_obj"), [])
+
+    mlx_lm_handler = _load_handler_class(monkeypatch)
+    handler = mlx_lm_handler.__new__(mlx_lm_handler)
+    handler.model = mock_model
+    handler.inference_worker = mock_inference_worker
+    handler.prompt_cache = mock_prompt_cache
+    handler.reasoning_parser_name = ""
+    handler.tool_parser_name = ""
+    handler.debug = False
+    handler.model_path = "/fake"
+    handler.model_created = 12345
+    handler.model_type = "text"
+    handler.enable_auto_tool_choice = False
+    handler.message_converter = Mock()
+
+    handler._prepare_text_request = AsyncMock(return_value=([], {}))
+    handler.refine_messages = Mock(return_value=[])
+
+    mock_parsers_result = Mock()
+    mock_parsers_result.is_unified = False
+    mock_parsers_result.reasoning_parser = None
+    mock_parsers_result.tool_parser = None
+    with patch('app.handler.mlx_lm.ParserManager.create_parsers', return_value=mock_parsers_result):
+        fake_request = Mock()
+        gen = handler.generate_text_stream(fake_request)
+        try:
+            async for _ in gen:
+                pass
+        finally:
+            await gen.aclose()
+
+        mock_prompt_cache.insert_cache.assert_called_once()
+        call_args = mock_prompt_cache.insert_cache.call_args
+        inserted_key = call_args[0][0]
+        inserted_cache = call_args[0][1]
+        assert inserted_key == [1, 2, 3, 4, 5, 6]
+        assert inserted_cache is mock_prompt_cache.fetch_nearest_cache.return_value[0]
+
+
+@pytest.mark.asyncio
+async def test_prompt_cache_inserted_on_cancellation_before_any_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that the prompt cache is inserted when the generator is closed before any chunk is processed, using only the initial input_ids."""
+    mock_model = Mock()
+    mock_model.create_input_prompt.return_value = "prompt"
+    input_ids = [1, 2, 3]
+    mock_model.encode_prompt.return_value = input_ids
+    mock_model.create_prompt_cache.return_value = Mock(name="cache_obj")
+
+    mock_inference_worker = Mock()
+
+    async def blocked_response_gen() -> AsyncGenerator[None, None]:
+        await asyncio.Event().wait()
+        yield  # unreachable, but makes it an async generator
+
+    mock_inference_worker.submit_stream = Mock(
+        side_effect=lambda *args, **kwargs: blocked_response_gen()
+    )
+
+    mock_prompt_cache = Mock()
+    mock_prompt_cache.fetch_nearest_cache.return_value = (Mock(name="cache_obj"), [])
+
+    mlx_lm_handler = _load_handler_class(monkeypatch)
+    handler = mlx_lm_handler.__new__(mlx_lm_handler)
+    handler.model = mock_model
+    handler.inference_worker = mock_inference_worker
+    handler.prompt_cache = mock_prompt_cache
+    handler.reasoning_parser_name = ""
+    handler.tool_parser_name = ""
+    handler.debug = False
+    handler.model_path = "/fake"
+    handler.model_created = 12345
+    handler.model_type = "text"
+    handler.enable_auto_tool_choice = False
+    handler.message_converter = Mock()
+
+    handler._prepare_text_request = AsyncMock(return_value=([], {}))
+    handler.refine_messages = Mock(return_value=[])
+
+    mock_parsers_result = Mock()
+    mock_parsers_result.is_unified = False
+    mock_parsers_result.reasoning_parser = None
+    mock_parsers_result.tool_parser = None
+    with patch('app.handler.mlx_lm.ParserManager.create_parsers', return_value=mock_parsers_result):
+        fake_request = Mock()
+        gen = handler.generate_text_stream(fake_request)
+        task = asyncio.create_task(gen.__anext__())
+        await asyncio.sleep(0)
+        task.cancel()
+        with suppress(asyncio.CancelledError, StopAsyncIteration, GeneratorExit):
+            await task
+        await gen.aclose()
+
+        mock_prompt_cache.insert_cache.assert_called_once()
+        call_args = mock_prompt_cache.insert_cache.call_args
+        inserted_key = call_args[0][0]
+        inserted_cache = call_args[0][1]
+        assert inserted_key == [1, 2, 3]
+        assert inserted_cache is mock_prompt_cache.fetch_nearest_cache.return_value[0]
+
+
+@pytest.mark.asyncio
+async def test_prompt_cache_inserted_on_cancellation_after_multiple_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that the prompt cache is inserted after processing multiple chunks and then cancelling, with the cache key including all processed tokens."""
+    mock_model = Mock()
+    mock_model.create_input_prompt.return_value = "prompt"
+    input_ids = [1, 2, 3]
+    mock_model.encode_prompt.return_value = input_ids
+    mock_model.create_prompt_cache.return_value = Mock(name="cache_obj")
+
+    mock_inference_worker = Mock()
+
+    async def mock_response_gen() -> AsyncGenerator[Mock, None]:
+        for token in [4, 5, 6]:
+            chunk = Mock()
+            chunk.text = f"Token {token}"
+            chunk.token = token
+            yield chunk
+
+    mock_inference_worker.submit_stream = Mock(side_effect=lambda *args, **kwargs: mock_response_gen())
+
+    mock_prompt_cache = Mock()
+    mock_prompt_cache.fetch_nearest_cache.return_value = (Mock(name="cache_obj"), [])
+
+    mlx_lm_handler = _load_handler_class(monkeypatch)
+    handler = mlx_lm_handler.__new__(mlx_lm_handler)
+    handler.model = mock_model
+    handler.inference_worker = mock_inference_worker
+    handler.prompt_cache = mock_prompt_cache
+    handler.reasoning_parser_name = ""
+    handler.tool_parser_name = ""
+    handler.debug = False
+    handler.model_path = "/fake"
+    handler.model_created = 12345
+    handler.model_type = "text"
+    handler.enable_auto_tool_choice = False
+    handler.message_converter = Mock()
+
+    handler._prepare_text_request = AsyncMock(return_value=([], {}))
+    handler.refine_messages = Mock(return_value=[])
+
+    mock_parsers_result = Mock()
+    mock_parsers_result.is_unified = False
+    mock_parsers_result.reasoning_parser = None
+    mock_parsers_result.tool_parser = None
+    with patch('app.handler.mlx_lm.ParserManager.create_parsers', return_value=mock_parsers_result):
+        fake_request = Mock()
+        gen = handler.generate_text_stream(fake_request)
+        try:
+            chunk_count = 0
+            async for _ in gen:
+                chunk_count += 1
+                if chunk_count == 2:
+                    break
+        finally:
+            await gen.aclose()
+
+        mock_prompt_cache.insert_cache.assert_called_once()
+        call_args = mock_prompt_cache.insert_cache.call_args
+        inserted_key = call_args[0][0]
+        inserted_cache = call_args[0][1]
+        assert inserted_key == [1, 2, 3, 4, 5]
+        assert inserted_cache is mock_prompt_cache.fetch_nearest_cache.return_value[0]


### PR DESCRIPTION
  ## Summary
  This PR makes streaming prompt-cache persistence resilient to cancellation/early close and adds regression coverage for cancellation paths.

  ## Problem
  When a streaming request was cancelled (for example client disconnect or generator close), prompt cache insertion could be skipped because insertion happened only on the normal end-of-stream path. That reduced
  cache reuse for subsequent requests.

  ## Changes
  - Add cancellation-safe cache persistence in `generate_text_stream`:
    - Track whether cache insertion already occurred.
    - Insert cache in a `finally` block when stream exits early.
    - Keep normal completion insertion behavior unchanged.
  - Preserve cancellation semantics:
    - Re-raise `asyncio.CancelledError` instead of converting it to HTTP 500.
  - Add focused tests for cache insertion behavior:
    - cancellation after first chunk
    - normal completion
    - cancellation before any chunk
    - cancellation after multiple chunks
  - Tests are written to avoid MLX device initialization so they run in constrained environments.

  ## Files
  - `app/handler/mlx_lm.py`
  - `tests/test_prompt_cache_cancellation.py`