### PR TITLE
feat(parsers): add Qwen3 and Qwen3.5 reasoning parsers

### DIFF
--- a/app/parsers/__init__.py
+++ b/app/parsers/__init__.py
@@ -20,15 +20,18 @@ from .kimi_k2 import KimiK2ToolParser
 from .longcat_flash_lite import LongCatFlashLiteToolParser
 from .minimax_m2 import MiniMaxM2ToolParser
 from .mixed_think_tool_handoff import MixedThinkToolHandoffReasoningParser, Step35ReasoningParser
+from .qwen3 import Qwen3ReasoningParser
+from .qwen3_5 import Qwen35ReasoningParser
 from .qwen3_moe import Qwen3MoEReasoningParser
 from .solar_open import SolarOpenReasoningParser, SolarOpenToolParser
 
 # Mapping from parser name strings to reasoning parser classes
 REASONING_PARSER_MAP: dict[str, type[AbstractReasoningParser]] = {
     "hermes": HermesReasoningParser,
-    "qwen3": HermesReasoningParser,  # use HermesReasoningParser for Qwen3
+    "qwen3": Qwen3ReasoningParser,
     "qwen3_moe": Qwen3MoEReasoningParser,
     "qwen3_vl": Qwen3MoEReasoningParser,  # use Qwen3MoEReasoningParser for Qwen3 VL
+    "qwen3_5": Qwen35ReasoningParser,
     "glm4_moe": GLM4MoEReasoningParser,
     "glm47_flash": Qwen3MoEReasoningParser,  # use Qwen3MoEReasoningParser for GLM47 Flash
     "minimax_m2": Qwen3MoEReasoningParser,  # use Qwen3MoEReasoningParser for MiniMax M2
@@ -303,7 +306,9 @@ __all__ = [
     "ToolParserState",
     # Reasoning parsers
     "HermesReasoningParser",
+    "Qwen3ReasoningParser",
     "Qwen3MoEReasoningParser",
+    "Qwen35ReasoningParser",
     "GLM4MoEReasoningParser",
     "SolarOpenReasoningParser",
     "MixedThinkToolHandoffReasoningParser",

--- a/app/parsers/qwen3.py
+++ b/app/parsers/qwen3.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from .hermes import HermesReasoningParser
+
+REASONING_OPEN = "<think>"
+REASONING_CLOSE = "</think>"
+
+
+class Qwen3ReasoningParser(HermesReasoningParser):
+    """Reasoning parser for Qwen3 MoE model's reasoning response format.
+
+    Handles the Qwen3 model's reasoning response format:
+    <think>reasoning_content</think>
+    """
+
+    def __init__(self, reasoning_open: str = REASONING_OPEN, reasoning_close: str = REASONING_CLOSE) -> None:
+        """Initialize the Qwen3 reasoning parser with appropriate regex patterns."""
+        super().__init__(reasoning_open=reasoning_open, reasoning_close=reasoning_close)
+
+    def respects_enable_thinking(self) -> bool:
+        """Check if the reasoning parser respects the enable_thinking flag.
+        
+        Returns
+        -------
+        bool
+            True if the reasoning parser respects the enable_thinking flag, False otherwise.
+        """
+        return True

--- a/app/parsers/qwen3_5.py
+++ b/app/parsers/qwen3_5.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from .qwen3_moe import Qwen3MoEReasoningParser
+
+REASONING_OPEN = "<think>"
+REASONING_CLOSE = "</think>"
+
+
+class Qwen35ReasoningParser(Qwen3MoEReasoningParser):
+    """Reasoning parser for Qwen3 MoE model's reasoning response format.
+
+    Handles the Qwen3.5 model's reasoning response format:
+    reasoning_content</think>
+    """
+
+    def __init__(self, reasoning_open: str = REASONING_OPEN, reasoning_close: str = REASONING_CLOSE) -> None:
+        """Initialize the Qwen3.5 reasoning parser with appropriate regex patterns."""
+        super().__init__(reasoning_open=reasoning_open, reasoning_close=reasoning_close)
+
+    def respects_enable_thinking(self) -> bool:
+        """Check if the reasoning parser respects the enable_thinking flag.
+        
+        Returns
+        -------
+        bool
+            True if the reasoning parser respects the enable_thinking flag, False otherwise.
+        """
+        return True


### PR DESCRIPTION
- Introduced Qwen3ReasoningParser and Qwen35ReasoningParser to handle specific reasoning response formats for Qwen3 and Qwen3.5 models.
- Updated REASONING_PARSER_MAP to include new parsers.
- Enhanced __all__ exports to include the new parser classes.