### PR TITLE
Refactor/versioning

### DIFF
--- a/app/version.py
+++ b/app/version.py
@@ -1,6 +1,51 @@
-# Version number format: MAJOR.MINOR.PATCH
-# Major: Major version number (increments when breaking changes are introduced)
-# Minor: Minor version number (increments when new features are added)
-# Patch: Patch version number (increments when bug fixes are made)
+"""Version helpers for the MLX OpenAI Server package."""
 
-__version__ = "1.6.2"   
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+import tomllib
+from typing import Final
+
+PACKAGE_NAME: Final[str] = "mlx-openai-server"
+
+
+def _read_version_from_pyproject() -> str:
+    """Read the project version directly from ``pyproject.toml``.
+
+    Returns
+    -------
+    str
+        Version string defined in the project's ``[project]`` table.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``pyproject.toml`` cannot be found relative to this module.
+    KeyError
+        If the expected ``project.version`` key is missing.
+    """
+
+    pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    with pyproject_path.open("rb") as pyproject_file:
+        project_data = tomllib.load(pyproject_file)
+    return project_data["project"]["version"]
+
+
+def get_version() -> str:
+    """Return the current package version.
+
+    Returns
+    -------
+    str
+        Installed package version when available, otherwise the version
+        declared in the local ``pyproject.toml`` file.
+    """
+
+    try:
+        return version(PACKAGE_NAME)
+    except PackageNotFoundError:
+        return _read_version_from_pyproject()
+
+
+__version__: Final[str] = get_version()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "mlx-openai-server"
+version = "1.6.2"
 description = "A high-performance API server that provides OpenAI-compatible endpoints for MLX models."
 readme = "README.md"
 requires-python = ">=3.11,<3.13"
 license = { text = "MIT" }
-dynamic = ["version"]
 authors = [{ name = "Gia-Huy Vuong", email = "cubist38@gmail.com" }]
 keywords = [
   "mlx",
@@ -74,9 +74,6 @@ include = ["app*"]
 
 [tool.setuptools.package-data]
 app = ["py.typed"]
-
-[tool.setuptools.dynamic]
-version = { attr = "app.version.__version__" }
 
 [project.urls]
 Homepage = "https://github.com/cubist38/mlx-openai-server"


### PR DESCRIPTION
## refactor: use pyproject.toml as single source of truth for version

- Move version from `app/version.py` into `pyproject.toml` and remove setuptools dynamic version handling.
- Update `app/version.py` to read the version from `pyproject.toml` via `get_version()`, using `importlib.metadata` when installed and falling back to parsing `pyproject.toml` in development.
- Ensures the version is defined in one place and stays consistent across installs and dev setups.