### PR TITLE
fix: convert tool_call arguments from JSON string to dict

### DIFF
--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import AsyncGenerator
+import json
 import gc
 from http import HTTPStatus
 import time
@@ -947,6 +948,17 @@ class MLXLMHandler:
             non_system_messages = []
 
             for message in request_dict.pop("messages", []):
+                # Convert tool_call arguments from JSON string to dict
+                # (OpenAI API spec: string, HuggingFace chat template: dict)
+                for tc in message.get("tool_calls") or []:
+                    fn = tc.get("function") or {}
+                    args = fn.get("arguments")
+                    if isinstance(args, str):
+                        try:
+                            fn["arguments"] = json.loads(args)
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+
                 # Reasoning content is output metadata and should not be replayed
                 # into subsequent prompt history turns.
                 message.pop("reasoning_content", None)


### PR DESCRIPTION
## Summary
  - OpenAI API spec defines `tool_calls[].function.arguments` as a JSON **string**, but HuggingFace chat templates
  (e.g. Qwen3.5) expect it as a **dict** to iterate with Jinja2's `|items` filter
  - Without this conversion, `apply_chat_template()` raises `TypeError: Can only get item pairs from a mapping`
  - This occurs in multi-turn tool calling when the client includes previous assistant messages with `tool_calls` in
  the conversation history

  ## Changes
  - Added `json.loads()` conversion in `_prepare_text_request()` before messages are passed to the chat template