### PR TITLE
Per model sampling defaults in Yaml config

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -59,19 +59,6 @@ from ..schemas.openai import (
     UsageInfo,
     random_uuid,
 )
-from openai.types.responses import FunctionTool
-from openai.types.responses.response_output_message import (
-    ResponseOutputText,
-    ResponseOutputMessage
-)
-from openai.types.responses.response_function_tool_call import (
-    ResponseFunctionToolCall
-)
-from openai.types.responses.response_reasoning_item import (
-    Summary,
-    Content,
-    ResponseReasoningItem
-)
 from ..utils.debug_logging import log_debug_server_request
 from ..utils.errors import create_error_response
 
@@ -345,7 +332,12 @@ def refine_chat_completion_request(
             handler, "default_seed", "DEFAULT_SEED", _parse_env_int
         )
     if request.repetition_penalty is None:
-        request.repetition_penalty = _parse_env_float("DEFAULT_REPETITION_PENALTY")
+        request.repetition_penalty = _get_sampling_default(
+            handler,
+            "default_repetition_penalty",
+            "DEFAULT_REPETITION_PENALTY",
+            _parse_env_float,
+        )
     if request.max_completion_tokens is None and request.max_tokens is None:
         request.max_completion_tokens = _get_sampling_default(
             handler, "default_max_tokens", "DEFAULT_MAX_TOKENS", _parse_env_int
@@ -1385,7 +1377,12 @@ def refine_responses_request(
             handler, "default_seed", "DEFAULT_SEED", _parse_env_int
         )
     if request.repetition_penalty is None:
-        request.repetition_penalty = _parse_env_float("DEFAULT_REPETITION_PENALTY")
+        request.repetition_penalty = _get_sampling_default(
+            handler,
+            "default_repetition_penalty",
+            "DEFAULT_REPETITION_PENALTY",
+            _parse_env_float,
+        )
     if request.max_output_tokens is None:
         request.max_output_tokens = _get_sampling_default(
             handler, "default_max_tokens", "DEFAULT_MAX_TOKENS", _parse_env_int
@@ -1779,8 +1776,6 @@ async def responses_endpoint(
     request: ResponsesRequest, raw_request: Request
 ) -> ResponsesResponse | StreamingResponse | JSONResponse:
     """Handle Responses API requests (OpenAI-compatible)."""
-    if not request.model:
-        request.model = Config.TEXT_MODEL
     handler = _resolve_handler(raw_request, model_id=request.model)
     if handler is None:
         return JSONResponse(

--- a/app/config.py
+++ b/app/config.py
@@ -65,6 +65,7 @@ class MLXServerConfig:
     default_top_p: float = 1.0
     default_top_k: int = 20
     default_min_p: float = 0.0
+    default_repetition_penalty: float = 1.0
     default_presence_penalty: float = 0.0
     default_xtc_probability: float = 0.0
     default_xtc_threshold: float = 0.0
@@ -202,6 +203,7 @@ class ModelEntryConfig:
     default_top_p: float | None = None
     default_top_k: int | None = None
     default_min_p: float | None = None
+    default_repetition_penalty: float | None = None
     default_presence_penalty: float | None = None
     default_xtc_probability: float | None = None
     default_xtc_threshold: float | None = None

--- a/app/core/handler_process.py
+++ b/app/core/handler_process.py
@@ -340,6 +340,7 @@ class HandlerProcessProxy:
         "default_top_p",
         "default_top_k",
         "default_min_p",
+        "default_repetition_penalty",
         "default_presence_penalty",
         "default_xtc_probability",
         "default_xtc_threshold",

--- a/app/server.py
+++ b/app/server.py
@@ -63,6 +63,7 @@ _SAMPLING_DEFAULT_FIELDS: tuple[str, ...] = (
     "default_top_p",
     "default_top_k",
     "default_min_p",
+    "default_repetition_penalty",
     "default_presence_penalty",
     "default_xtc_probability",
     "default_xtc_threshold",

--- a/tests/test_multi_model_per_model_defaults.py
+++ b/tests/test_multi_model_per_model_defaults.py
@@ -19,6 +19,7 @@ PER_MODEL_DEFAULTS_A: dict[str, int | float] = {
     "default_top_p": 0.95,
     "default_top_k": 35,
     "default_min_p": 0.0,
+    "default_repetition_penalty": 1.11,
     "default_seed": 111,
     "default_max_tokens": 180000,
     "default_xtc_probability": 0.11,
@@ -32,6 +33,7 @@ PER_MODEL_DEFAULTS_B: dict[str, int | float] = {
     "default_top_p": 0.9,
     "default_top_k": 20,
     "default_min_p": 0.05,
+    "default_repetition_penalty": 1.22,
     "default_seed": 222,
     "default_max_tokens": 60000,
     "default_xtc_probability": 0.22,
@@ -45,6 +47,7 @@ GLOBAL_ENV_DEFAULTS: dict[str, str] = {
     "DEFAULT_TOP_P": "0.5",
     "DEFAULT_TOP_K": "99",
     "DEFAULT_MIN_P": "0.9",
+    "DEFAULT_REPETITION_PENALTY": "1.5",
     "DEFAULT_SEED": "999",
     "DEFAULT_MAX_TOKENS": "42",
     "DEFAULT_XTC_PROBABILITY": "0.77",
@@ -96,11 +99,13 @@ class _FakeRegistry:
         return self._handlers[model_id]
 
 
-def _make_raw_request(registry: _FakeRegistry) -> Any:
+def _make_raw_request(registry: _FakeRegistry, handler: Any | None = None) -> Any:
     """Build a minimal request-like object for endpoint unit tests."""
 
     return types.SimpleNamespace(
-        app=types.SimpleNamespace(state=types.SimpleNamespace(registry=registry)),
+        app=types.SimpleNamespace(
+            state=types.SimpleNamespace(registry=registry, handler=handler)
+        ),
         state=types.SimpleNamespace(request_id="req-test"),
     )
 
@@ -115,6 +120,7 @@ def _single_model_handler_with_implicit_defaults() -> Any:
         default_top_p=config.default_top_p,
         default_top_k=config.default_top_k,
         default_min_p=config.default_min_p,
+        default_repetition_penalty=config.default_repetition_penalty,
         default_seed=config.default_seed,
         default_max_tokens=config.default_max_tokens,
         default_xtc_probability=config.default_xtc_probability,
@@ -137,6 +143,7 @@ def test_load_config_from_yaml_preserves_per_model_sampling_defaults(tmp_path: P
         "    default_top_p: 0.95\n"
         "    default_top_k: 35\n"
         "    default_min_p: 0.0\n"
+        "    default_repetition_penalty: 1.11\n"
         "    default_seed: 111\n"
         "    default_max_tokens: 180000\n"
         "    default_xtc_probability: 0.11\n"
@@ -150,6 +157,7 @@ def test_load_config_from_yaml_preserves_per_model_sampling_defaults(tmp_path: P
         "    default_top_p: 0.9\n"
         "    default_top_k: 20\n"
         "    default_min_p: 0.05\n"
+        "    default_repetition_penalty: 1.22\n"
         "    default_seed: 222\n"
         "    default_max_tokens: 60000\n"
         "    default_xtc_probability: 0.22\n"
@@ -205,6 +213,7 @@ async def test_chat_completions_can_apply_different_defaults_per_model(
         top_k=None,
         min_p=None,
         seed=None,
+        repetition_penalty=None,
         max_completion_tokens=None,
         max_tokens=None,
         xtc_probability=None,
@@ -220,6 +229,7 @@ async def test_chat_completions_can_apply_different_defaults_per_model(
         top_k=None,
         min_p=None,
         seed=None,
+        repetition_penalty=None,
         max_completion_tokens=None,
         max_tokens=None,
         xtc_probability=None,
@@ -237,6 +247,9 @@ async def test_chat_completions_can_apply_different_defaults_per_model(
     assert captured_requests[0].top_p == pytest.approx(PER_MODEL_DEFAULTS_A["default_top_p"])
     assert captured_requests[0].top_k == PER_MODEL_DEFAULTS_A["default_top_k"]
     assert captured_requests[0].min_p == pytest.approx(PER_MODEL_DEFAULTS_A["default_min_p"])
+    assert captured_requests[0].repetition_penalty == pytest.approx(
+        PER_MODEL_DEFAULTS_A["default_repetition_penalty"]
+    )
     assert captured_requests[0].seed == PER_MODEL_DEFAULTS_A["default_seed"]
     assert captured_requests[0].max_completion_tokens == PER_MODEL_DEFAULTS_A["default_max_tokens"]
     assert captured_requests[0].xtc_probability == pytest.approx(
@@ -259,6 +272,9 @@ async def test_chat_completions_can_apply_different_defaults_per_model(
     assert captured_requests[1].top_p == pytest.approx(PER_MODEL_DEFAULTS_B["default_top_p"])
     assert captured_requests[1].top_k == PER_MODEL_DEFAULTS_B["default_top_k"]
     assert captured_requests[1].min_p == pytest.approx(PER_MODEL_DEFAULTS_B["default_min_p"])
+    assert captured_requests[1].repetition_penalty == pytest.approx(
+        PER_MODEL_DEFAULTS_B["default_repetition_penalty"]
+    )
     assert captured_requests[1].seed == PER_MODEL_DEFAULTS_B["default_seed"]
     assert captured_requests[1].max_completion_tokens == PER_MODEL_DEFAULTS_B["default_max_tokens"]
     assert captured_requests[1].xtc_probability == pytest.approx(
@@ -307,6 +323,7 @@ async def test_single_model_implicit_handler_defaults_do_not_shadow_env_defaults
         top_p=None,
         top_k=None,
         min_p=None,
+        repetition_penalty=None,
         seed=None,
         max_completion_tokens=None,
         max_tokens=None,
@@ -322,6 +339,9 @@ async def test_single_model_implicit_handler_defaults_do_not_shadow_env_defaults
     assert captured_requests[0].top_p == pytest.approx(float(GLOBAL_ENV_DEFAULTS["DEFAULT_TOP_P"]))
     assert captured_requests[0].top_k == int(GLOBAL_ENV_DEFAULTS["DEFAULT_TOP_K"])
     assert captured_requests[0].min_p == pytest.approx(float(GLOBAL_ENV_DEFAULTS["DEFAULT_MIN_P"]))
+    assert captured_requests[0].repetition_penalty == pytest.approx(
+        float(GLOBAL_ENV_DEFAULTS["DEFAULT_REPETITION_PENALTY"])
+    )
     assert captured_requests[0].seed == int(GLOBAL_ENV_DEFAULTS["DEFAULT_SEED"])
     assert captured_requests[0].max_completion_tokens == int(GLOBAL_ENV_DEFAULTS["DEFAULT_MAX_TOKENS"])
     assert captured_requests[0].xtc_probability == pytest.approx(
@@ -372,6 +392,7 @@ async def test_chat_completions_explicit_request_values_override_model_defaults(
         top_p=0.44,
         top_k=12,
         min_p=0.22,
+        repetition_penalty=1.23,
         seed=555,
         max_completion_tokens=77,
         xtc_probability=0.12,
@@ -386,6 +407,7 @@ async def test_chat_completions_explicit_request_values_override_model_defaults(
     assert captured_requests[0].top_p == pytest.approx(0.44)
     assert captured_requests[0].top_k == 12
     assert captured_requests[0].min_p == pytest.approx(0.22)
+    assert captured_requests[0].repetition_penalty == pytest.approx(1.23)
     assert captured_requests[0].seed == 555
     assert captured_requests[0].max_completion_tokens == 77
     assert captured_requests[0].xtc_probability == pytest.approx(0.12)
@@ -418,6 +440,7 @@ async def test_responses_can_apply_different_defaults_per_model(
         top_p=None,
         top_k=None,
         min_p=None,
+        repetition_penalty=None,
         seed=None,
         max_output_tokens=None,
     )
@@ -428,6 +451,7 @@ async def test_responses_can_apply_different_defaults_per_model(
         top_p=None,
         top_k=None,
         min_p=None,
+        repetition_penalty=None,
         seed=None,
         max_output_tokens=None,
     )
@@ -441,6 +465,9 @@ async def test_responses_can_apply_different_defaults_per_model(
     assert refined_request_a.top_p == pytest.approx(PER_MODEL_DEFAULTS_A["default_top_p"])
     assert refined_request_a.top_k == PER_MODEL_DEFAULTS_A["default_top_k"]
     assert refined_request_a.min_p == pytest.approx(PER_MODEL_DEFAULTS_A["default_min_p"])
+    assert refined_request_a.repetition_penalty == pytest.approx(
+        PER_MODEL_DEFAULTS_A["default_repetition_penalty"]
+    )
     assert refined_request_a.seed == PER_MODEL_DEFAULTS_A["default_seed"]
     assert refined_request_a.max_output_tokens == PER_MODEL_DEFAULTS_A["default_max_tokens"]
 
@@ -450,6 +477,9 @@ async def test_responses_can_apply_different_defaults_per_model(
     assert refined_request_b.top_p == pytest.approx(PER_MODEL_DEFAULTS_B["default_top_p"])
     assert refined_request_b.top_k == PER_MODEL_DEFAULTS_B["default_top_k"]
     assert refined_request_b.min_p == pytest.approx(PER_MODEL_DEFAULTS_B["default_min_p"])
+    assert refined_request_b.repetition_penalty == pytest.approx(
+        PER_MODEL_DEFAULTS_B["default_repetition_penalty"]
+    )
     assert refined_request_b.seed == PER_MODEL_DEFAULTS_B["default_seed"]
     assert refined_request_b.max_output_tokens == PER_MODEL_DEFAULTS_B["default_max_tokens"]
 
@@ -472,6 +502,7 @@ async def test_responses_single_model_implicit_handler_defaults_do_not_shadow_en
         top_p=None,
         top_k=None,
         min_p=None,
+        repetition_penalty=None,
         seed=None,
         max_output_tokens=None,
     )
@@ -482,5 +513,45 @@ async def test_responses_single_model_implicit_handler_defaults_do_not_shadow_en
     assert refined_request.top_p == pytest.approx(float(GLOBAL_ENV_DEFAULTS["DEFAULT_TOP_P"]))
     assert refined_request.top_k == int(GLOBAL_ENV_DEFAULTS["DEFAULT_TOP_K"])
     assert refined_request.min_p == pytest.approx(float(GLOBAL_ENV_DEFAULTS["DEFAULT_MIN_P"]))
+    assert refined_request.repetition_penalty == pytest.approx(
+        float(GLOBAL_ENV_DEFAULTS["DEFAULT_REPETITION_PENALTY"])
+    )
     assert refined_request.seed == int(GLOBAL_ENV_DEFAULTS["DEFAULT_SEED"])
     assert refined_request.max_output_tokens == int(GLOBAL_ENV_DEFAULTS["DEFAULT_MAX_TOKENS"])
+
+
+@pytest.mark.asyncio
+async def test_responses_omitted_model_uses_backward_compatible_fallback_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitted-model Responses requests should still fall back to app.state.handler."""
+
+    endpoints_module = _load_endpoints_module()
+    captured_requests: list[ResponsesRequest] = []
+    captured_handlers: list[Any] = []
+
+    async def _fake_process_text_responses_request(
+        handler: Any,
+        request: ResponsesRequest,
+    ) -> JSONResponse:
+        captured_handlers.append(handler)
+        captured_requests.append(request.model_copy(deep=True))
+        return JSONResponse(content={"ok": True})
+
+    fallback_handler = types.SimpleNamespace(
+        handler_type="lm", _uses_model_sampling_defaults=True, **PER_MODEL_DEFAULTS_A
+    )
+    registry = _FakeRegistry({"model-a": fallback_handler})
+
+    monkeypatch.setattr(
+        endpoints_module, "process_text_responses_request", _fake_process_text_responses_request
+    )
+
+    request = ResponsesRequest(input="hello", model=None)
+    response = await endpoints_module.responses_endpoint(
+        request, _make_raw_request(registry, handler=fallback_handler)
+    )
+
+    assert isinstance(response, JSONResponse)
+    assert captured_handlers == [fallback_handler]
+    assert captured_requests[0].model is None


### PR DESCRIPTION
## What this changes

This makes sampling defaults genuinely model-aware in multi-model mode.

Before this change, omitted generation fields effectively came from process-global `DEFAULT_*` env values, which meant
a multi-model server could load different models but not give them different default generation behavior.

After this change, omitted fields can come from the selected model's configured defaults.

## Scope

This PR adds per-model defaults for the current sampling-default surface and applies them after model routing for:

- chat completions
- responses

It also preserves existing compatibility behavior that came up during review:

- explicit client-supplied request values still win
- single-model programmatic startup still falls back to ambient `DEFAULT_*` env values
- omitted-model `/v1/responses` requests still preserve the old fallback-to-`app.state.handler` behavior
- `repetition_penalty` is included in the per-model default surface, not left env-only

## Key implementation points

- add per-model `default_*` fields to `ModelEntryConfig`
- attach those defaults to multi-model handlers / subprocess proxies
- refine chat and Responses requests using the selected handler's defaults first
- gate handler-sourced defaults behind an explicit marker so only intentionally model-bound defaults are used
- restore backward-compatible `/v1/responses` omitted-model fallback by not forcing `Config.TEXT_MODEL` before handler
resolution

## Tests

Added regression coverage for:

- different models getting different omitted chat defaults
- explicit request values overriding model defaults
- single-model env fallback surviving chat default refinement
- different models getting different omitted Responses defaults
- single-model env fallback surviving Responses default refinement
- omitted-model Responses requests preserving backward-compatible fallback behavior
- YAML preserving per-model default fields, including `repetition_penalty`