### PR TITLE
API compat fallback contract hardening

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -225,7 +225,10 @@ def _should_use_legacy_chat_fallback(
     try:
         registry.get_handler(Config.TEXT_MODEL)
     except KeyError:
-        return getattr(raw_request.app.state, "handler", None) is not None
+        fallback_handler = getattr(raw_request.app.state, "handler", None)
+        if fallback_handler is None:
+            return False
+        return _get_handler_type(fallback_handler) in ("lm", "multimodal")
 
     return False
 

--- a/tests/test_multi_model_per_model_defaults.py
+++ b/tests/test_multi_model_per_model_defaults.py
@@ -639,6 +639,44 @@ async def test_chat_completions_omitted_model_uses_backward_compatible_fallback_
 
 
 @pytest.mark.asyncio
+async def test_chat_completions_omitted_model_does_not_fallback_to_non_chat_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitted chat requests should not route to a non-chat fallback handler."""
+
+    endpoints_module = _load_endpoints_module()
+    captured_handlers: list[Any] = []
+
+    async def _fake_process_text_request(
+        handler: Any,
+        request: ChatCompletionRequest,
+        request_id: str | None = None,
+    ) -> JSONResponse:
+        del request, request_id
+        captured_handlers.append(handler)
+        return JSONResponse(content={"ok": True})
+
+    fallback_handler = types.SimpleNamespace(handler_type="embeddings")
+    registry_handler = types.SimpleNamespace(
+        handler_type="lm", _uses_model_sampling_defaults=True, **PER_MODEL_DEFAULTS_A
+    )
+    registry = _FakeRegistry({"model-a": registry_handler})
+
+    monkeypatch.setattr(endpoints_module, "process_text_request", _fake_process_text_request)
+
+    request = ChatCompletionRequest(messages=[Message(role="user", content="hello")])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await endpoints_module.chat_completions(
+            request, _make_raw_request(registry, handler=fallback_handler)
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail["error"]["type"] == "model_not_found"
+    assert captured_handlers == []
+
+
+@pytest.mark.asyncio
 async def test_chat_completions_omitted_model_reports_resolved_fallback_model_id() -> None:
     """Omitted-model chat requests should report the resolved fallback handler's model id."""
 


### PR DESCRIPTION
## Summary

This tightens the backward-compatibility contract for omitted-model chat and Responses requests.

The main behavior change is narrow and intentional:

- omitted legacy-default requests should still work
- explicit `model="local-text-model"` requests should still 404 when that alias is not registered
- fallback-served responses should report the resolved handler model back to clients
- single-model mode should continue to preserve the legacy `local-text-model` alias

## What this changes

- limits chat fallback-to-`app.state.handler` to the true compatibility case:
  - the client omitted `model`
  - validation filled in the legacy alias
  - that alias is not actually registered

- preserves `model_not_found` for explicit unregistered:
  - `model="local-text-model”`
  on both:
  - `/v1/chat/completions`
  - `/v1/responses`

- fixes model labeling so omitted-model fallback requests report the resolved handler id instead of the stale legacy
alias

- keeps single-model omitted requests on the legacy alias contract, even if handlers/proxies later grow concrete
`model_id` fields

## Coverage

Added / expanded tests for:

- omitted-model chat fallback routing
- omitted-model chat model labeling in non-stream and stream paths
- explicit legacy alias still 404ing when unregistered
- omitted-model Responses fallback routing
- omitted-model Responses model labeling in non-stream and stream paths
- single-model legacy alias preservation for chat and Responses, in both non-stream and stream modes
