### PR TITLE
feat: update mflux installation instructions and add dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,6 @@ source .venv/bin/activate
 # Install core server from PyPI
 uv pip install mlx-openai-server
 
-# Optional: install image generation/editing support separately
-# `mlx-openai-server[image]` is not available yet because PyPI rejects
-# git-based direct dependencies in published package metadata.
-uv pip install git+https://github.com/cubist38/mflux.git
-
 # Or install from GitHub
 uv pip install git+https://github.com/cubist38/mlx-openai-server.git
 ```

--- a/app/cli.py
+++ b/app/cli.py
@@ -31,9 +31,8 @@ else:
     MFLUX_IMPORT_ERROR = None
 
 MFLUX_INSTALL_HINT = (
-    "Image generation and editing require the optional `mflux` package. "
-    "Install a compatible build separately, for example "
-    "`pip install git+https://github.com/cubist38/mflux.git`."
+    "Image generation and editing require the `mflux` package. "
+    "Install it with `pip install mflux==0.17.0`."
 )
 
 

--- a/app/server.py
+++ b/app/server.py
@@ -41,9 +41,8 @@ from .handler.mlx_whisper import MLXWhisperHandler
 from .version import __version__
 
 MFLUX_INSTALL_HINT = (
-    "Image generation and editing require the optional `mflux` package. "
-    "Install a compatible build separately, for example "
-    "`pip install git+https://github.com/cubist38/mflux.git`."
+    "Image generation and editing require the `mflux` package. "
+    "Install it with `pip install mflux==0.17.0`."
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
   "python-multipart>=0.0.20,<0.0.25",
   "rich>=14,<15",
   "torchvision>=0.23.0,<0.30",
+  "mflux==0.17.0",
   "uvicorn>=0.35.0,<0.40",
 ]
 


### PR DESCRIPTION
 ## Summary                                                                                                                
  - Add `mflux==0.17.0` as a regular dependency in `pyproject.toml` (no longer needs separate install from fork)
  - Remove separate install instructions from README                                                                        
  - Update install hint messages in `cli.py` and `server.py`                                                                
                                                                                                                            
  mflux 0.17.0 now allows MLX 0.31.x in its dependency ranges, so the forked build is no longer needed. 