### PR TITLE
fix: resolve on-demand text model for omitted-model responses with non-text fallback

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -85,6 +85,12 @@ def _get_handler_type(handler: Any) -> str:
     return getattr(handler, "handler_type", "")
 
 
+def _is_text_compatible_handler(handler: Any | None) -> bool:
+    """Return whether a handler can serve chat/Responses text requests."""
+
+    return _get_handler_type(handler) in ("lm", "multimodal")
+
+
 async def _resolve_handler(
     raw_request: Request,
     model_id: str | None = None,
@@ -280,7 +286,7 @@ def _should_use_legacy_chat_fallback(
         fallback_handler = getattr(raw_request.app.state, "handler", None)
         if fallback_handler is None:
             return False
-        return _get_handler_type(fallback_handler) in ("lm", "multimodal")
+        return _is_text_compatible_handler(fallback_handler)
 
     return False
 
@@ -2060,6 +2066,15 @@ async def responses_endpoint(
             ),
             status_code=HTTPStatus.SERVICE_UNAVAILABLE,
         )
+
+    if request.model is None and not _is_text_compatible_handler(handler):
+        # Resolve the legacy text alias instead of binding a non-text
+        # fallback handler to Responses.  In multi-model mode this
+        # triggers registry/on-demand lookup; in single-model mode the
+        # second resolve is a no-op and the downstream type check
+        # still rejects the non-text handler.
+        handler = await _resolve_handler(raw_request, model_id=Config.TEXT_MODEL)
+        request.model = Config.TEXT_MODEL
 
     try:
         _normalize_request_model(raw_request, request, handler)

--- a/tests/test_multi_model_per_model_defaults.py
+++ b/tests/test_multi_model_per_model_defaults.py
@@ -94,11 +94,31 @@ def _load_endpoints_module() -> Any:
 class _FakeRegistry:
     """Minimal registry stub that resolves handlers by model id."""
 
-    def __init__(self, handlers: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        handlers: dict[str, Any],
+        on_demand_handlers: dict[str, Any] | None = None,
+    ) -> None:
         self._handlers = handlers
+        self._on_demand_handlers = on_demand_handlers or {}
 
     def get_handler(self, model_id: str) -> Any:
         return self._handlers[model_id]
+
+    def is_on_demand(self, model_id: str) -> bool:
+        return model_id in self._on_demand_handlers
+
+    async def ensure_on_demand_loaded(self, model_id: str) -> Any:
+        handler = self._on_demand_handlers[model_id]
+        self._handlers[model_id] = handler
+        return handler
+
+    async def release_on_demand(self, model_id: str) -> None:
+        if model_id in self._on_demand_handlers:
+            self._handlers.pop(model_id, None)
+
+    def list_model_ids(self) -> list[str]:
+        return sorted(set(self._handlers.keys()) | set(self._on_demand_handlers.keys()))
 
 
 def _make_raw_request(registry: _FakeRegistry | None, handler: Any | None = None) -> Any:
@@ -597,6 +617,73 @@ async def test_responses_omitted_model_uses_backward_compatible_fallback_handler
 
     assert isinstance(response, JSONResponse)
     assert captured_handlers == [fallback_handler]
+
+
+@pytest.mark.asyncio
+async def test_responses_omitted_model_does_not_fallback_to_non_text_handler() -> None:
+    """Omitted Responses requests should not route to a non-text fallback handler."""
+
+    endpoints_module = _load_endpoints_module()
+
+    fallback_handler = types.SimpleNamespace(handler_type="whisper")
+    registry_handler = types.SimpleNamespace(
+        handler_type="lm", _uses_model_sampling_defaults=True, **PER_MODEL_DEFAULTS_A
+    )
+    registry = _FakeRegistry({"model-a": registry_handler})
+
+    request = ResponsesRequest(input="hello", model=None)
+    with pytest.raises(HTTPException) as exc_info:
+        await endpoints_module.responses_endpoint(
+            request, _make_raw_request(registry, handler=fallback_handler)
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail["error"]["type"] == "model_not_found"
+
+
+@pytest.mark.asyncio
+async def test_responses_omitted_model_non_text_fallback_uses_on_demand_default_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitted Responses should resolve ``local-text-model`` via on-demand load."""
+
+    endpoints_module = _load_endpoints_module()
+    captured_handlers: list[Any] = []
+
+    async def _fake_process_text_responses_request(
+        handler: Any,
+        request: ResponsesRequest,
+    ) -> JSONResponse:
+        del request
+        captured_handlers.append(handler)
+        return JSONResponse(content={"ok": True})
+
+    fallback_handler = types.SimpleNamespace(handler_type="whisper")
+    on_demand_text_handler = types.SimpleNamespace(
+        handler_type="lm",
+        served_model_name=Config.TEXT_MODEL,
+        model_path="mlx-community/model-text",
+        debug=False,
+    )
+    registry = _FakeRegistry(
+        {"model-a": types.SimpleNamespace(handler_type="lm")},
+        on_demand_handlers={Config.TEXT_MODEL: on_demand_text_handler},
+    )
+
+    monkeypatch.setattr(
+        endpoints_module,
+        "process_text_responses_request",
+        _fake_process_text_responses_request,
+    )
+
+    request = ResponsesRequest(input="hello", model=None)
+    response = await endpoints_module.responses_endpoint(
+        request, _make_raw_request(registry, handler=fallback_handler)
+    )
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 200
+    assert captured_handlers == [on_demand_text_handler]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Omitted-model `/v1/responses` requests returned a false 404 (`model_not_found`) when
the app's fallback handler was non-text (e.g. whisper) and the default text alias
(`local-text-model`) was registered on-demand but not currently loaded.

The fix mirrors chat's omitted-model path: when the resolved fallback handler isn't
text-compatible, resolve `Config.TEXT_MODEL` through the registry/on-demand loader
instead of failing with a 404.

## Changes

- Extract `_is_text_compatible_handler()` helper (reused in both the legacy chat
  fallback check and the new responses guard).
- In `responses_endpoint`, when `request.model` is `None` and the fallback handler
  is non-text, resolve `Config.TEXT_MODEL` via `_resolve_handler` and normalize the
  request model accordingly.

## Tests

- `test_responses_omitted_model_does_not_fallback_to_non_text_handler` — verifies
  the 404 still fires when the text alias is genuinely absent.
- `test_responses_omitted_model_non_text_fallback_uses_on_demand_default_alias` (new)
  — verifies omitted-model responses resolves and uses the on-demand text handler.
- Expanded `_FakeRegistry` stub with on-demand semantics (`is_on_demand`,
  `ensure_on_demand_loaded`, `release_on_demand`, `list_model_ids`).

## Design note

Uses a post-resolution guard rather than mirroring chat's pre-resolution pattern to
minimize changes to the responses entry path. Happy to refactor toward chat's
pre-resolution approach if preferred.