### PR TITLE
chore: update dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "PyYAML>=6.0,<7",
   "python-multipart>=0.0.20,<0.0.25",
   "rich>=14,<15",
-  "torchvision>=0.23.0,<0.30",
+  "opencv-python-headless>=4.11,<5",
   "mflux==0.17.0",
   "uvicorn>=0.35.0,<0.40",
 ]


### PR DESCRIPTION
Fix duplicate FFmpeg dylib warnings by removing torchvision

## Summary
- Remove `torchvision` dependency — it's not imported anywhere in the app source code
- Replace with `opencv-python-headless` to satisfy `mflux`'s opencv requirement without bundling FFmpeg dylibs
- This eliminates the conflicting FFmpeg libraries from `av` and `opencv-python` that cause macOS runtime warnings and potential crashes

Fixes #209

## Details
`torchvision` was pulling in `opencv-python`, which bundles its own FFmpeg dylibs that conflict with the `av` package's copies (`libavdevice.62` vs `libavdevice.61`). The app only needs `torch` (for `torch.Tensor` type checking in mlx-vlm handlers), which is already provided transitively by `mlx-whisper` and `mflux`.
