### PR TITLE
docs: add "Frequently Encountered Problems" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A high-performance OpenAI-compatible API server for MLX models. Run text, vision
 - [Example Notebooks](#example-notebooks)
 - [Large Models](#large-models)
 - [Troubleshooting](#troubleshooting)
+- [Frequently Encountered Problems](#frequently-encountered-problems)
 - [Quick Reference Card](#quick-reference-card)
 - [Featured Launch: MiniMax-M2.5-Uncensored-4bit](#featured-launch-minimax-m25-uncensored-4bit)
 - [Contributing](#contributing)
@@ -738,6 +739,29 @@ This raises the system's wired memory limit for better performance.
 | **Port already in use** | Use `--port` to specify a different port (e.g. `--port 8001`). |
 | **Quantization questions** | For lm/multimodal, use pre-quantized models from [mlx-community](https://huggingface.co/mlx-community). For image models, use `--quantize 4` or `8`. |
 | **Metal/semaphore warnings** | Use multi-handler mode (`--config`); each model runs in a spawned subprocess to avoid Metal context issues. |
+
+---
+
+## Frequently Encountered Problems
+
+### Model loading errors (e.g. "parameters not in model")
+
+If you see errors like **"Received N parameters not in model"** or weight/parameter mismatches when loading a newly released model, the most common cause is an outdated version of the underlying MLX model library. New models often require the latest architecture support from `mlx-lm`, `mlx-vlm`, or other backend packages.
+
+**Fix:** Install the latest version directly from the source repository:
+
+```bash
+# For text models (lm)
+uv pip install git+https://github.com/ml-explore/mlx-lm.git
+
+# For multimodal models
+uv pip install git+https://github.com/Blaizzy/mlx-vlm.git
+
+# For embeddings
+uv pip install git+https://github.com/Blaizzy/mlx-embeddings.git
+```
+
+The git versions often contain support for new model architectures before a PyPI release is published. After upgrading, restart the server and try loading the model again.
 
 ---
 


### PR DESCRIPTION
Title: docs: add Frequently Encountered Problems section to README

Body:

## Summary
- Add a "Frequently Encountered Problems" section to the README addressing model loading errors (e.g. "Received N parameters not in model")
- Guide users to install the latest versions of `mlx-lm`, `mlx-vlm`, and `mlx-embeddings` directly from git to resolve compatibility issues with newly released models

## Context
Requested by a user in https://github.com/cubist38/mlx-openai-server/issues/261#issuecomment-4144714259. This is a common support pattern where users encounter parameter mismatches when loading new models. The root cause is typically an outdated version of the underlying MLX library that doesn't yet support the model's architecture. Directing users to install from git (where new architecture support lands before PyPI releases) should reduce these recurring issues.
