### PR TITLE
refactor: enhance on-demand model management in ModelRegistry

### DIFF
--- a/app/core/model_registry.py
+++ b/app/core/model_registry.py
@@ -386,7 +386,9 @@ class ModelRegistry:
                 if idle_task is not None:
                     idle_task.cancel()
                 old_handler = self._handlers.pop(loaded_id)
-                logger.info(f"Unloading on-demand model '{loaded_id}' to make room for '{model_id}'")
+                logger.info(
+                    f"Unloading on-demand model '{loaded_id}' to make room for '{model_id}'"
+                )
                 if hasattr(old_handler, "cleanup"):
                     await old_handler.cleanup()
                 self._on_demand_ref_count.pop(loaded_id, None)


### PR DESCRIPTION
Title: fix: prevent on-demand models from being unloaded during active requests (#262)

Body:

## Summary

- Fix a bug where on-demand models were forcefully unloaded mid-request when a different on-demand model was requested, even if the current model still had active requests (ref_count > 0)
- Change `_on_demand_loaded` from a single model tracker (`str | None`) to a `set[str]`, allowing multiple on-demand models to coexist temporarily while requests are in-flight
- Change `_on_demand_idle_task` from a single shared task to per-model idle tasks (`dict[str, asyncio.Task]`), so each model gets its own independent idle timeout

## Root Cause

In `ensure_on_demand_loaded`, when a new on-demand model was requested and a different one was already loaded, the old model was unconditionally unloaded — its handler was cleaned up and its ref_count was wiped — regardless of whether it was still processing requests. This caused errors for any in-flight requests using that model.

## What Changed

`app/core/model_registry.py`:
- `ensure_on_demand_loaded` now only unloads idle on-demand models (ref_count == 0) when making room for a new model. Models with active requests are kept loaded alongside the new model and will be cleaned up by their own idle timer once all requests complete.
- Idle timeout tasks are now tracked per-model instead of as a single global task.
- `cleanup_all` updated to cancel all per-model idle tasks on shutdown.

Fixes #262