### PR TITLE
refactor: update cache insertion method to use cache_type parameter

### DIFF
--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -352,7 +352,7 @@ class MLXLMHandler:
                     _store.insert_cache(
                         _prefix_ids,
                         copy.deepcopy(prompt_cache_state),
-                        checkpoint=True,
+                        cache_type="system",
                     )
 
                 logger.info(f"Non-trimmable cache: will checkpoint prefix at {boundary} tokens")

--- a/app/utils/prompt_cache.py
+++ b/app/utils/prompt_cache.py
@@ -122,8 +122,7 @@ class PromptTrie:
                     if best is None or len(extra) < len(best):
                         best = extra
                 elif best is None or len(extra) < len(best):
-                    for tok in current:
-                        stack.append((current[tok], [*extra, tok]))
+                    stack.extend((current[tok], [*extra, tok]) for tok in current)
             if best is not None:
                 longer = tokens[:index] + best
 
@@ -190,13 +189,22 @@ class LRUPromptCache:
             # Fall through to the last queue
             return self._lrus[self._ordering[-1]].popleft()
 
+        @property
+        def ordering(self) -> list[str]:
+            """Return the priority ordering."""
+            return self._ordering
+
+        def count_by_type(self, cache_type: str) -> int:
+            """Return the number of entries of the given type."""
+            return len(self._lrus[cache_type])
+
     def __init__(self, max_size: int = 10, max_bytes: int = 1 << 63) -> None:
         self.max_size = max_size
         self.max_bytes = max_bytes
         self._trie = PromptTrie()
         self._lru = self.CacheOrder()
         self._n_bytes = 0
-        self._n_bytes_by_type: dict[str, int] = dict.fromkeys(self._lru._ordering, 0)
+        self._n_bytes_by_type: dict[str, int] = dict.fromkeys(self._lru.ordering, 0)
 
     def __len__(self) -> int:
         return len(self._lru)
@@ -314,9 +322,9 @@ class LRUPromptCache:
     def stats_by_type(self) -> dict[str, dict[str, int]]:
         """Return per-type sequence count and byte usage."""
         result = {}
-        for cache_type in self._lru._ordering:
+        for cache_type in self._lru.ordering:
             result[cache_type] = {
-                "n_sequences": len(self._lru._lrus[cache_type]),
+                "n_sequences": self._lru.count_by_type(cache_type),
                 "n_bytes": self._n_bytes_by_type[cache_type],
             }
         return result
@@ -333,9 +341,8 @@ class LRUPromptCache:
 if __name__ == "__main__":
     from app.models.mlx_lm import MLX_LM
 
-    model_path = "mlx-community/Qwen3-Coder-Next-8bit"
-    draft_model_path = "mlx-community/Qwen3-Coder-Next-4bit"
-    model = MLX_LM(model_path, draft_model_path)
+    model_path = "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit"
+    model = MLX_LM(model_path)
     prompt_cache = LRUPromptCache()
 
     import time

--- a/app/utils/prompt_cache.py
+++ b/app/utils/prompt_cache.py
@@ -1,14 +1,133 @@
-# modified from https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/server.py
+# modified from https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/cache.py
 
 from __future__ import annotations
 
-from collections import deque
 import copy
+from collections import deque
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
 from loguru import logger
 from mlx_lm.models.cache import can_trim_prompt_cache, trim_prompt_cache
+
+
+@dataclass
+class PromptTrieResult:
+    """Result of searching the trie for a token sequence.
+
+    Parameters
+    ----------
+    exact : list[int] | None
+        Exact matching token sequence, if found.
+    shorter : list[int] | None
+        Shorter prefix match, if found.
+    longer : list[int] | None
+        Longer sequence containing the query as a prefix, if found.
+    common_prefix : int
+        Length of common prefix with matching cache entries.
+    """
+
+    exact: Optional[list[int]]
+    shorter: Optional[list[int]]
+    longer: Optional[list[int]]
+    common_prefix: int
+
+
+class PromptTrie:
+    """Prefix trie for storing prompt caches keyed by token sequences."""
+
+    def __init__(self) -> None:
+        self._trie: dict[int, Any] = {}
+
+    def add(self, tokens: list[int], value: Any) -> Any:
+        """Insert a value and return the previous value if any."""
+        current = self._trie
+        for tok in tokens:
+            if tok not in current:
+                current[tok] = {}
+            current = current[tok]
+        prev = current.get("__value__", None)
+        current["__value__"] = value
+        return prev
+
+    def get(self, tokens: list[int]) -> Any:
+        """Exact lookup by token sequence."""
+        current = self._trie
+        for tok in tokens:
+            current = current[tok]
+        return current["__value__"]
+
+    def pop(self, tokens: list[int]) -> Any:
+        """Remove and return the value at the given token sequence."""
+        path = [self._trie]
+        for tok in tokens:
+            path.append(path[-1][tok])
+        value = path[-1].pop("__value__")
+        for i in range(len(tokens), 0, -1):
+            node = path[i]
+            parent = path[i - 1]
+            tok = tokens[i - 1]
+            if len(node) > 0:
+                break
+            del parent[tok]
+        return value
+
+    def pop_prefixes(self, tokens: list[int]) -> list[tuple[int, Any]]:
+        """Remove all prefix entries along the path to *tokens*."""
+        values = []
+        current = self._trie
+        for i, tok in enumerate(tokens):
+            if "__value__" in current:
+                values.append((i, current.pop("__value__")))
+            current = current[tok]
+        return values
+
+    def search(self, tokens: list[int]) -> PromptTrieResult:
+        """Search for exact, shorter, or longer matches."""
+        if not self._trie:
+            return PromptTrieResult(None, None, None, 0)
+
+        current = self._trie
+
+        if not tokens and "__value__" in current:
+            return PromptTrieResult([], None, None, 0)
+
+        # Walk the tokens as far as we can
+        last_index = -1
+        index = 0
+        while index < len(tokens) and tokens[index] in current:
+            current = current[tokens[index]]
+            if "__value__" in current:
+                last_index = index
+            index += 1
+
+        # Got an exact match
+        if last_index == len(tokens) - 1 >= 0:
+            return PromptTrieResult(tokens, None, None, 0)
+
+        # Check if we found a prefix at any point
+        shorter = None
+        if last_index > 0:
+            shorter = tokens[: last_index + 1]
+
+        # Check for sequences that are longer (DFS with pruning)
+        longer = None
+        common_prefix = index
+        if index > 0:
+            best = None
+            stack = [(current, [])]
+            while stack:
+                current, extra = stack.pop()
+                if "__value__" in current:
+                    if best is None or len(extra) < len(best):
+                        best = extra
+                elif best is None or len(extra) < len(best):
+                    for tok in current:
+                        stack.append((current[tok], [*extra, tok]))
+            if best is not None:
+                longer = tokens[:index] + best
+
+        return PromptTrieResult(None, shorter, longer, common_prefix)
 
 
 class LRUPromptCache:
@@ -30,160 +149,61 @@ class LRUPromptCache:
 
     @dataclass
     class CacheEntry:
-        """Stored prompt cache entry.
-
-        Parameters
-        ----------
-        prompt_cache : list[Any]
-            Prompt cache object stored for the token sequence.
-        nbytes : int
-            Approximate number of bytes consumed by the prompt cache.
-        """
+        """Stored prompt cache entry."""
 
         prompt_cache: list[Any]
         nbytes: int
+        cache_type: str
 
     class CacheOrder:
-        """Track cache recency while prioritizing checkpoint retention."""
+        """Track cache recency with priority-based eviction."""
 
-        def __init__(self) -> None:
-            """Initialize checkpoint-aware LRU queues."""
-            self._lru_checkpoints: deque[tuple[int, ...]] = deque()
-            self._lru: deque[tuple[int, ...]] = deque()
+        def __init__(self, ordering: list[str] | None = None) -> None:
+            if ordering is None:
+                ordering = ["assistant", "user", "system"]
+            self._ordering = ordering
+            self._lrus: dict[str, deque[tuple[int, ...]]] = {k: deque() for k in ordering}
 
         def __len__(self) -> int:
-            """Return the total number of tracked cache entries."""
-            return len(self._lru) + len(self._lru_checkpoints)
+            return sum(len(lru) for lru in self._lrus.values())
 
-        def push(self, tokens: tuple[int, ...], checkpoint: bool = False) -> None:
-            """Append an entry to the appropriate LRU queue."""
-            queue = self._lru_checkpoints if checkpoint else self._lru
-            queue.append(tokens)
+        def push(self, tokens: tuple[int, ...], cache_type: str = "assistant") -> None:
+            self._lrus[cache_type].append(tokens)
 
         def remove(self, tokens: tuple[int, ...]) -> None:
-            """Remove an entry from whichever queue currently contains it."""
-            try:
-                self._lru.remove(tokens)
-            except ValueError:
-                self._lru_checkpoints.remove(tokens)
+            for cache_type in self._ordering:
+                try:
+                    self._lrus[cache_type].remove(tokens)
+                    break
+                except ValueError:
+                    pass
 
         def pop(self) -> tuple[int, ...]:
-            """Pop the least-recently-used entry, balancing checkpoints."""
-            if len(self._lru) >= len(self._lru_checkpoints):
-                return self._lru.popleft()
-            return self._lru_checkpoints.popleft()
-
-    @dataclass
-    class SearchResult:
-        """Result of searching the trie for a token sequence.
-
-        Parameters
-        ----------
-        exact : list[int] | None
-            Exact matching token sequence, if found.
-        shorter : list[int] | None
-            Shorter prefix match, if found.
-        longer : list[int] | None
-            Longer sequence containing the query as a prefix, if found.
-        common_prefix : int
-            Length of common prefix with matching cache entries.
-        """
-
-        exact: list[int] | None
-        shorter: list[int] | None
-        longer: list[int] | None
-        common_prefix: int
+            """Pop the least-recently-used entry, favouring lower-priority types."""
+            i = 0
+            while i + 1 < len(self._ordering):
+                lru_a = self._lrus[self._ordering[i]]
+                lru_b = self._lrus[self._ordering[i + 1]]
+                if lru_a and len(lru_a) >= len(lru_b):
+                    return lru_a.popleft()
+                i += 1
+            # Fall through to the last queue
+            return self._lrus[self._ordering[-1]].popleft()
 
     def __init__(self, max_size: int = 10, max_bytes: int = 1 << 63) -> None:
-        """Initialize the LRU prompt cache."""
         self.max_size = max_size
         self.max_bytes = max_bytes
-        self._cache: dict[int, Any] = {}
+        self._trie = PromptTrie()
         self._lru = self.CacheOrder()
         self._n_bytes = 0
+        self._n_bytes_by_type: dict[str, int] = {k: 0 for k in self._lru._ordering}
 
     def __len__(self) -> int:
-        """Return the number of cached sequences."""
         return len(self._lru)
 
     @property
     def nbytes(self) -> int:
-        """Return the approximate total bytes held by cached entries."""
         return self._n_bytes
-
-    def _prompt_cache_nbytes(self, prompt_cache: list[Any]) -> int:
-        """Estimate the size in bytes of a prompt cache.
-
-        Parameters
-        ----------
-        prompt_cache : list[Any]
-            Prompt cache layers to size.
-
-        Returns
-        -------
-        int
-            Best-effort byte count for the provided prompt cache.
-        """
-        total = 0
-        for layer in prompt_cache:
-            try:
-                total += int(getattr(layer, "nbytes", 0))
-            except (TypeError, ValueError):
-                continue
-        return total
-
-    def _search(self, tokens_ids: list[int]) -> SearchResult:
-        """Search the cache for a prompt cache.
-
-        Parameters
-        ----------
-        tokens_ids : list[int]
-            Token sequence to search for.
-
-        Returns
-        -------
-        SearchResult
-            Matching information for exact, shorter, or longer cache hits.
-        """
-        if not self._cache:
-            return self.SearchResult(None, None, None, 0)
-
-        current = self._cache
-        last_cache_index = -1
-        index = 0
-
-        while index < len(tokens_ids) and tokens_ids[index] in current:
-            current = current[tokens_ids[index]]
-            if "cache" in current:
-                last_cache_index = index
-            index += 1
-
-        if last_cache_index == len(tokens_ids) - 1:
-            return self.SearchResult(tokens_ids, None, None, 0)
-
-        shorter = None
-        if last_cache_index > 0:
-            shorter = tokens_ids[: last_cache_index + 1]
-
-        longer = None
-        common_prefix = index
-        if index > 0:
-            # BFS guarantees the first cache hit is the shallowest (shortest
-            # extra tokens), so we can stop immediately instead of exploring
-            # the entire subtree.
-            best = None
-            queue = deque([(current, [])])
-            while queue:
-                node, extra = queue.popleft()
-                if "cache" in node:
-                    best = extra
-                    break
-                for tok in node:
-                    queue.append((node[tok], [*extra, tok]))
-            if best is not None:
-                longer = tokens_ids[:index] + best
-
-        return self.SearchResult(None, shorter, longer, common_prefix)
 
     def fetch_nearest_cache(
         self,
@@ -191,25 +211,20 @@ class LRUPromptCache:
     ) -> tuple[list[Any] | None, list[int]]:
         """Fetch the nearest matching cache for the given token sequence.
 
-        Parameters
-        ----------
-        tokens_ids : list[int]
-            Token sequence to find a cache for.
-
         Returns
         -------
         tuple[list[Any] | None, list[int]]
             Tuple of (prompt_cache, remaining_tokens). If no cache found,
             returns (None, original_tokens).
         """
-        result = self._search(tokens_ids)
+        result = self._trie.search(tokens_ids)
         if result.exact is not None:
-            cache_entry = self._get(result.exact)
+            cache_entry = self._trie.get(result.exact)
             return copy.deepcopy(cache_entry.prompt_cache), []
 
         short_length = len(result.shorter) if result.shorter is not None else 0
         if result.longer is not None and result.common_prefix > short_length:
-            cache_entry = self._get(result.longer)
+            cache_entry = self._trie.get(result.longer)
             if can_trim_prompt_cache(cache_entry.prompt_cache):
                 cache = copy.deepcopy(cache_entry.prompt_cache)
                 prefix = min(len(tokens_ids) - 1, result.common_prefix)
@@ -218,60 +233,17 @@ class LRUPromptCache:
                 return cache, tokens_ids[prefix:]
 
         if short_length > 0:
-            cache_entry = self._get(result.shorter)
+            cache_entry = self._trie.get(result.shorter)
             return copy.deepcopy(cache_entry.prompt_cache), tokens_ids[short_length:]
 
         return None, tokens_ids
-
-    def _get(self, tokens_ids: list[int]) -> CacheEntry:
-        """Retrieve a cache entry without removing it.
-
-        Parameters
-        ----------
-        tokens_ids : list[int]
-            Token sequence identifying the cache entry.
-
-        Returns
-        -------
-        CacheEntry
-            The cache entry at this location.
-
-        Raises
-        ------
-        KeyError
-            If the token sequence is not in the cache.
-        """
-        current = self._cache
-        for tok in tokens_ids:
-            current = current[tok]
-        return current["cache"]
-
-    def _delete(self, tokens_ids: list[int]) -> None:
-        """Delete a cache entry and clean up empty trie nodes.
-
-        Parameters
-        ----------
-        tokens_ids : list[int]
-            Token sequence identifying the cache entry to delete.
-        """
-        path = [self._cache]
-        for tok in tokens_ids:
-            path.append(path[-1][tok])
-
-        cache_bytes = path[-1]["cache"].nbytes
-        self._n_bytes -= cache_bytes
-        del path[-1]["cache"]
-        for i in reversed(range(len(tokens_ids))):
-            d_prev, d, t = path[i], path[i + 1], tokens_ids[i]
-            if len(d) > 0:
-                break
-            del d_prev[t]
 
     def insert_cache(
         self,
         tokens_ids: list[int],
         prompt_cache: list[Any],
-        checkpoint: bool = False,
+        *,
+        cache_type: str = "assistant",
     ) -> None:
         """Insert or update a cache entry.
 
@@ -281,71 +253,80 @@ class LRUPromptCache:
             Token sequence identifying this cache entry.
         prompt_cache : list[Any]
             The prompt cache data to store.
-        checkpoint : bool, optional
-            Whether to keep this entry in the checkpoint-priority queue, by
-            default ``False``.
+        cache_type : str, optional
+            Priority category for eviction ordering, by default ``"assistant"``.
         """
         tokens_tuple = tuple(tokens_ids)
 
-        is_trimmable = can_trim_prompt_cache(prompt_cache)
-        current = self._cache
-        for index, tok in enumerate(tokens_ids):
-            if tok not in current:
-                current[tok] = {}
-            if is_trimmable and "cache" in current:
-                self._n_bytes -= current["cache"].nbytes
-                del current["cache"]
-                self._lru.remove(tuple(tokens_ids[:index]))
-            current = current[tok]
+        # Make the cache entry
+        entry = self.CacheEntry(
+            prompt_cache, sum(getattr(c, "nbytes", 0) for c in prompt_cache), cache_type
+        )
 
-        if "cache" in current:
-            self._n_bytes -= current["cache"].nbytes
+        # Insert into the trie and update the byte counter and lru position
+        self._n_bytes += entry.nbytes
+        self._n_bytes_by_type[cache_type] += entry.nbytes
+        prev = self._trie.add(tokens_ids, entry)
+        if prev is not None:
+            self._n_bytes -= prev.nbytes
+            self._n_bytes_by_type[prev.cache_type] -= prev.nbytes
             self._lru.remove(tokens_tuple)
-        cache_bytes = self._prompt_cache_nbytes(prompt_cache)
-        current["cache"] = self.CacheEntry(prompt_cache, cache_bytes)
-        self._n_bytes += cache_bytes
+        self._lru.push(tokens_tuple, cache_type)
 
-        self._lru.push(tokens_tuple, checkpoint=checkpoint)
+        # If it is a trimmable cache remove all prefixes cause they just take
+        # space
+        if can_trim_prompt_cache(prompt_cache):
+            for prefix_len, removed_entry in self._trie.pop_prefixes(tokens_ids):
+                self._n_bytes -= removed_entry.nbytes
+                self._n_bytes_by_type[removed_entry.cache_type] -= removed_entry.nbytes
+                self._lru.remove(tuple(tokens_ids[:prefix_len]))
 
+        # Ensure we match the constraints
         if len(self._lru) > self.max_size:
-            oldest_tokens = self._lru.pop()
-            self._delete(list(oldest_tokens))
+            evicted = self._lru.pop()
+            evicted_entry = self._trie.pop(list(evicted))
+            self._n_bytes -= evicted_entry.nbytes
+            self._n_bytes_by_type[evicted_entry.cache_type] -= evicted_entry.nbytes
 
-        while self._n_bytes > self.max_bytes and len(self._lru) > 1:
-            oldest_tokens = self._lru.pop()
-            self._delete(list(oldest_tokens))
+        while self._n_bytes > self.max_bytes:
+            evicted = self._lru.pop()
+            evicted_entry = self._trie.pop(list(evicted))
+            self._n_bytes -= evicted_entry.nbytes
+            self._n_bytes_by_type[evicted_entry.cache_type] -= evicted_entry.nbytes
 
     def trim_to(self, *, n_sequences: int | None = None, n_bytes: int | None = None) -> None:
-        """Trim the cache down to sequence and/or byte limits.
-
-        Parameters
-        ----------
-        n_sequences : int | None, optional
-            Maximum number of sequences to retain, by default ``None``.
-        n_bytes : int | None, optional
-            Maximum number of bytes to retain, by default ``None``.
-        """
+        """Trim the cache down to sequence and/or byte limits."""
         max_sequences = max(0, n_sequences) if n_sequences is not None else 1 << 63
         max_bytes = max(0, n_bytes) if n_bytes is not None else 1 << 63
 
         while len(self._lru) > max_sequences:
-            oldest_tokens = self._lru.pop()
-            self._delete(list(oldest_tokens))
+            evicted = self._lru.pop()
+            evicted_entry = self._trie.pop(list(evicted))
+            self._n_bytes -= evicted_entry.nbytes
+            self._n_bytes_by_type[evicted_entry.cache_type] -= evicted_entry.nbytes
 
         while self._n_bytes > max_bytes:
-            oldest_tokens = self._lru.pop()
-            self._delete(list(oldest_tokens))
+            evicted = self._lru.pop()
+            evicted_entry = self._trie.pop(list(evicted))
+            self._n_bytes -= evicted_entry.nbytes
+            self._n_bytes_by_type[evicted_entry.cache_type] -= evicted_entry.nbytes
+
+    def stats_by_type(self) -> dict[str, dict[str, int]]:
+        """Return per-type sequence count and byte usage."""
+        result = {}
+        for cache_type in self._lru._ordering:
+            result[cache_type] = {
+                "n_sequences": len(self._lru._lrus[cache_type]),
+                "n_bytes": self._n_bytes_by_type[cache_type],
+            }
+        return result
 
     def log_cache_stats(self) -> None:
-        """Log the current cache size, bytes, and latest checkpoint token count."""
-        latest_checkpoint_tokens = (
-            len(self._lru._lru_checkpoints[-1]) if self._lru._lru_checkpoints else 0  # noqa: SLF001
-        )
+        """Log the current cache size, bytes, and per-type stats."""
         logger.info(
-            "KV Caches: {} seq, {:.2f} GB, latest user cache {} tokens",
+            "KV Caches: {} seq, {:.2f} GB",
             len(self),
             self.nbytes / 1e9,
-            latest_checkpoint_tokens,
         )
 
 

--- a/app/utils/prompt_cache.py
+++ b/app/utils/prompt_cache.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import copy
 from collections import deque
+import copy
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 from loguru import logger
 from mlx_lm.models.cache import can_trim_prompt_cache, trim_prompt_cache
@@ -27,9 +27,9 @@ class PromptTrieResult:
         Length of common prefix with matching cache entries.
     """
 
-    exact: Optional[list[int]]
-    shorter: Optional[list[int]]
-    longer: Optional[list[int]]
+    exact: list[int] | None
+    shorter: list[int] | None
+    longer: list[int] | None
     common_prefix: int
 
 
@@ -196,7 +196,7 @@ class LRUPromptCache:
         self._trie = PromptTrie()
         self._lru = self.CacheOrder()
         self._n_bytes = 0
-        self._n_bytes_by_type: dict[str, int] = {k: 0 for k in self._lru._ordering}
+        self._n_bytes_by_type: dict[str, int] = dict.fromkeys(self._lru._ordering, 0)
 
     def __len__(self) -> int:
         return len(self._lru)

--- a/tests/test_non_trimmable_checkpoint.py
+++ b/tests/test_non_trimmable_checkpoint.py
@@ -108,7 +108,7 @@ class TestNonTrimmableCacheReuse:
         fake_prefix_cache = [Mock(nbytes=100, state=[])]
         fake_full_cache = [Mock(nbytes=200, state=[])]
 
-        cache.insert_cache(prefix_tokens, fake_prefix_cache, checkpoint=True)
+        cache.insert_cache(prefix_tokens, fake_prefix_cache, cache_type="system")
         cache.insert_cache(full_request_1, fake_full_cache)
 
         result_cache, rest = cache.fetch_nearest_cache(full_request_2)


### PR DESCRIPTION
refactor: align LRUPromptCache with upstream mlx-lm implementation

## Summary

- Extract `PromptTrie` and `PromptTrieResult` as standalone classes, matching the upstream `mlx_lm.models.cache` structure
- Replace `checkpoint: bool` with `cache_type: str` (`"assistant"`, `"user"`, `"system"`) for priority-based eviction ordering
- Use `pop_prefixes` for cleaner prefix removal when inserting trimmable caches
- Track per-type byte usage (`_n_bytes_by_type`) and add `stats_by_type()` method
- Switch from BFS to DFS with pruning for finding longer trie matches