### PR TITLE
Feature/kv cache quantization

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -272,6 +272,24 @@ def cli():
     type=int,
     help="Number of draft tokens per step when using speculative decoding (--draft-model-path). Only supported with model type 'lm'. Default is 2.",
 )
+@click.option(
+    "--kv-bits",
+    default=None,
+    type=int,
+    help="Number of bits for KV cache quantization (e.g. 4, 8). Reduces memory usage at the cost of some quality. Only works with 'lm' and 'multimodal' model types.",
+)
+@click.option(
+    "--kv-group-size",
+    default=64,
+    type=int,
+    help="Group size for KV cache quantization. Default is 64.",
+)
+@click.option(
+    "--quantized-kv-start",
+    default=0,
+    type=int,
+    help="Step to begin using a quantized KV cache when --kv-bits is set. Default is 0.",
+)
 # Sampling parameters (defaults used when API request omits them)
 @click.option(
     "--max-tokens",
@@ -344,6 +362,9 @@ def launch(
     prompt_cache_max_bytes,
     draft_model_path,
     num_draft_tokens,
+    kv_bits,
+    kv_group_size,
+    quantized_kv_start,
     max_tokens,
     temperature,
     top_p,
@@ -412,6 +433,9 @@ def launch(
         prompt_cache_max_bytes=prompt_cache_max_bytes,
         draft_model_path=draft_model_path,
         num_draft_tokens=num_draft_tokens,
+        kv_bits=kv_bits,
+        kv_group_size=kv_group_size,
+        quantized_kv_start=quantized_kv_start,
         default_max_tokens=max_tokens,
         default_temperature=temperature,
         default_top_p=top_p,

--- a/app/config.py
+++ b/app/config.py
@@ -59,6 +59,11 @@ class MLXServerConfig:
     draft_model_path: str | None = None
     num_draft_tokens: int = 2
 
+    # KV cache quantization
+    kv_bits: int | None = None
+    kv_group_size: int = 64
+    quantized_kv_start: int = 0
+
     # Default sampling parameters (override DEFAULT_* env when set via CLI)
     default_max_tokens: int = 100000
     default_temperature: float = 1.0
@@ -122,6 +127,14 @@ class MLXServerConfig:
             )
             self.config_name = "flux-kontext-dev"
 
+        # KV cache quantization is only supported for lm and multimodal model types
+        if self.kv_bits is not None and self.model_type not in {"lm", "multimodal"}:
+            logger.warning(
+                "KV cache quantization (--kv-bits) is only supported for model types 'lm' and "
+                "'multimodal'. Ignoring KV cache quantization options."
+            )
+            self.kv_bits = None
+
         # Speculative decoding (draft model) is only supported for lm model type
         if self.draft_model_path and self.model_type != "lm":
             logger.warning(
@@ -177,6 +190,9 @@ class MLXServerConfig:
             prompt_cache_max_bytes=self.prompt_cache_max_bytes,
             draft_model_path=self.draft_model_path,
             num_draft_tokens=self.num_draft_tokens,
+            kv_bits=self.kv_bits,
+            kv_group_size=self.kv_group_size,
+            quantized_kv_start=self.quantized_kv_start,
         )
 
 
@@ -233,6 +249,9 @@ class ModelEntryConfig:
     prompt_cache_max_bytes: int = 1 << 63
     draft_model_path: str | None = None
     num_draft_tokens: int = 2
+    kv_bits: int | None = None
+    kv_group_size: int = 64
+    quantized_kv_start: int = 0
     default_max_tokens: int | None = None
     default_temperature: float | None = None
     default_top_p: float | None = None
@@ -270,6 +289,15 @@ class ModelEntryConfig:
                 self.model_path,
             )
             self.config_name = "flux-kontext-dev"
+
+        # KV cache quantization is LM/multimodal-only
+        if self.kv_bits is not None and self.model_type not in {"lm", "multimodal"}:
+            logger.warning(
+                "KV cache quantization is only supported for 'lm' and 'multimodal'. "
+                "Ignoring for model '%s'.",
+                self.model_path,
+            )
+            self.kv_bits = None
 
         # Speculative decoding is LM-only
         if self.draft_model_path and self.model_type != "lm":

--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -109,6 +109,9 @@ class MLXLMHandler:
         debug: bool = False,
         prompt_cache_size: int = 10,
         prompt_cache_max_bytes: int = 1 << 63,
+        kv_bits: int | None = None,
+        kv_group_size: int = 64,
+        quantized_kv_start: int = 0,
     ):
         """
         Initialize the handler with the specified model path.
@@ -141,6 +144,12 @@ class MLXLMHandler:
             Maximum number of prompt KV cache entries to store. Default is 10.
         prompt_cache_max_bytes : int
             Maximum total bytes retained by prompt KV caches before eviction.
+        kv_bits : int | None
+            Number of bits for KV cache quantization. None disables quantization.
+        kv_group_size : int
+            Group size for KV cache quantization. Default is 64.
+        quantized_kv_start : int
+            Step to begin using a quantized KV cache. Default is 0.
         """
         self.model_path = model_path
         self.model = MLX_LM(
@@ -154,6 +163,11 @@ class MLXLMHandler:
         )
         self.model_created = int(time.time())  # Store creation time when model is loaded
         self.model_type = self.model.get_model_type()
+
+        # KV cache quantization settings
+        self.kv_bits = kv_bits
+        self.kv_group_size = kv_group_size
+        self.quantized_kv_start = quantized_kv_start
 
         # Store parser configuration
         self.enable_auto_tool_choice = enable_auto_tool_choice
@@ -1034,6 +1048,9 @@ class MLXLMHandler:
                 "xtc_threshold": request.xtc_threshold,
                 "logit_bias": request.logit_bias,
                 "chat_template_kwargs": chat_template_kwargs,
+                "kv_bits": self.kv_bits,
+                "kv_group_size": self.kv_group_size,
+                "quantized_kv_start": self.quantized_kv_start,
             }
 
             if request.response_format:

--- a/app/handler/mlx_vlm.py
+++ b/app/handler/mlx_vlm.py
@@ -56,6 +56,9 @@ class MLXVLMHandler:
         trust_remote_code: bool = False,
         chat_template_file: str = None,
         debug: bool = False,
+        kv_bits: int | None = None,
+        kv_group_size: int = 64,
+        quantized_kv_start: int = 0,
     ):
         """
         Initialize the handler with the specified model path.
@@ -70,6 +73,9 @@ class MLXVLMHandler:
             reasoning_parser (str): Name of the reasoning parser to use (qwen3, qwen3_next, glm4_moe, harmony, minimax, ...).
             trust_remote_code (bool): Enable trust_remote_code when loading models.
             chat_template_file (str): Path to a custom chat template file.
+            kv_bits (int | None): Number of bits for KV cache quantization. None disables quantization.
+            kv_group_size (int): Group size for KV cache quantization. Default is 64.
+            quantized_kv_start (int): Step to begin using a quantized KV cache. Default is 0.
         """
         self.model_path = model_path
         self.model = MLX_VLM(
@@ -84,6 +90,11 @@ class MLXVLMHandler:
         self.disable_auto_resize = disable_auto_resize
         self.model_created = int(time.time())  # Store creation time when model is loaded
         self.model_type = self.model.get_model_type()
+
+        # KV cache quantization settings
+        self.kv_bits = kv_bits
+        self.kv_group_size = kv_group_size
+        self.quantized_kv_start = quantized_kv_start
 
         # Store parser configuration
         self.enable_auto_tool_choice = enable_auto_tool_choice
@@ -179,6 +190,9 @@ class MLXVLMHandler:
             "top_p": request_dict.get("top_p"),
             "schema": request_dict.get("schema"),
             "vision_inputs": vision_inputs,
+            "kv_bits": self.kv_bits,
+            "kv_group_size": self.kv_group_size,
+            "quantized_kv_start": self.quantized_kv_start,
         }
 
         parsers_result = ParserManager.create_parsers(

--- a/app/models/mlx_lm.py
+++ b/app/models/mlx_lm.py
@@ -302,6 +302,10 @@ class MLX_LM:
 
         sampler = make_sampler(**sampler_kwargs)
 
+        kv_bits = kwargs.get("kv_bits")
+        kv_group_size = kwargs.get("kv_group_size", 64)
+        quantized_kv_start = kwargs.get("quantized_kv_start", 0)
+
         stream_response = stream_generate(
             self.model,
             self.tokenizer,
@@ -313,6 +317,9 @@ class MLX_LM:
             prompt_cache=prompt_cache,
             logits_processors=logits_processors,
             prompt_progress_callback=prompt_progress_callback,
+            kv_bits=kv_bits,
+            kv_group_size=kv_group_size,
+            quantized_kv_start=quantized_kv_start,
         )
         if stream:
             return stream_response

--- a/app/models/mlx_vlm.py
+++ b/app/models/mlx_vlm.py
@@ -163,6 +163,13 @@ class MLX_VLM:
             "top_p": _get("top_p", DEFAULT_TOP_P),
         }
 
+        # KV cache quantization params
+        kv_bits = kwargs.get("kv_bits")
+        if kv_bits is not None:
+            sampling_params["kv_bits"] = kv_bits
+            sampling_params["kv_group_size"] = kwargs.get("kv_group_size", 64)
+            sampling_params["quantized_kv_start"] = kwargs.get("quantized_kv_start", 0)
+
         model_params.update(sampling_params)
 
         response_generator = stream_generate(

--- a/app/server.py
+++ b/app/server.py
@@ -256,6 +256,9 @@ def create_handler_from_config(model_cfg: ModelEntryConfig) -> Any:
                 trust_remote_code=model_cfg.trust_remote_code,
                 chat_template_file=model_cfg.chat_template_file,
                 debug=model_cfg.debug,
+                kv_bits=model_cfg.kv_bits,
+                kv_group_size=model_cfg.kv_group_size,
+                quantized_kv_start=model_cfg.quantized_kv_start,
             ),
             model_cfg,
         )
@@ -318,6 +321,9 @@ def create_handler_from_config(model_cfg: ModelEntryConfig) -> Any:
             prompt_cache_max_bytes=model_cfg.prompt_cache_max_bytes,
             draft_model_path=model_cfg.draft_model_path,
             num_draft_tokens=model_cfg.num_draft_tokens,
+            kv_bits=model_cfg.kv_bits,
+            kv_group_size=model_cfg.kv_group_size,
+            quantized_kv_start=model_cfg.quantized_kv_start,
         ),
         model_cfg,
     )


### PR DESCRIPTION
feat: add KV cache quantization support for LM and multimodal models

Closes https://github.com/cubist38/mlx-openai-server/issues/276

## Summary

- Add `--kv-bits`, `--kv-group-size`, and `--quantized-kv-start` CLI options and YAML config fields to enable KV cache quantization (including TurboQuant) for `lm` and `multimodal` model types
- Thread the parameters through config, handlers, and model wrappers to the underlying `generate_step` in both `mlx-lm` and `mlx-vlm`
- Validate and warn when KV cache quantization is specified for unsupported model types (e.g. embeddings, whisper)

## Usage

### CLI
```bash
mlx-openai-server launch --model-path <model> --kv-bits 4 --kv-group-size 64 --quantized-kv-start 0
```

### YAML config
```yaml
models:
  - model_path: mlx-community/Qwen3-VL-2B-Thinking-8bit
    model_type: multimodal
    kv_bits: 4
    kv_group_size: 64
    quantized_kv_start: 0
```

## Changed files

- `app/cli.py` — New `--kv-bits`, `--kv-group-size`, `--quantized-kv-start` CLI options
- `app/config.py` — New fields on `MLXServerConfig` and `ModelEntryConfig` with validation
- `app/server.py` — Pass KV params to LM and VLM handler constructors
- `app/handler/mlx_lm.py` — Accept, store, and include KV params in model_params
- `app/handler/mlx_vlm.py` — Accept, store, and include KV params in model_params
- `app/models/mlx_lm.py` — Forward KV params to `stream_generate`
- `app/models/mlx_vlm.py` — Forward KV params to `stream_generate`