### PR TITLE
fix(parsers): stop Qwen3.5 reasoning parser from absorbing <tool_call> blocks

### DIFF
--- a/app/parsers/qwen3_5.py
+++ b/app/parsers/qwen3_5.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
+from .abstract_parser import ReasoningParserState, _suffix_prefix_overlap
 from .qwen3_moe import Qwen3MoEReasoningParser
 
 REASONING_OPEN = "<think>"
 REASONING_CLOSE = "</think>"
+TOOL_OPEN = "<tool_call>"
 
 
 class Qwen35ReasoningParser(Qwen3MoEReasoningParser):
-    """Reasoning parser for Qwen3 MoE model's reasoning response format.
+    """Reasoning parser for Qwen3.5 model's reasoning response format.
 
     Handles the Qwen3.5 model's reasoning response format:
     reasoning_content</think>
+
+    Unlike the base Qwen3MoEReasoningParser, this parser stops collecting
+    reasoning content when it encounters a ``<tool_call>`` tag, even if the
+    closing ``</think>`` has not yet been seen.  The model occasionally emits
+    tool calls inside the ``<think>`` block; without this guard the entire
+    ``<tool_call>...</tool_call>`` payload is absorbed into ``reasoning_content``
+    and the downstream tool parser never receives it.
     """
 
     def __init__(
@@ -18,6 +27,7 @@ class Qwen35ReasoningParser(Qwen3MoEReasoningParser):
     ) -> None:
         """Initialize the Qwen3.5 reasoning parser with appropriate regex patterns."""
         super().__init__(reasoning_open=reasoning_open, reasoning_close=reasoning_close)
+        self.tool_open = TOOL_OPEN
 
     def respects_enable_thinking(self) -> bool:
         """Check if the reasoning parser respects the enable_thinking flag.
@@ -28,3 +38,136 @@ class Qwen35ReasoningParser(Qwen3MoEReasoningParser):
             True if the reasoning parser respects the enable_thinking flag, False otherwise.
         """
         return True
+
+    def extract_reasoning(self, model_output: str) -> dict[str, str] | None:
+        """Extract reasoning from complete output, stopping at the first ``<tool_call>``.
+
+        If a ``<tool_call>`` tag appears inside the ``<think>`` block, the text
+        from that point onward is returned as ``after_reasoning_close_content``
+        so the tool parser can process it normally.
+
+        Parameters
+        ----------
+        model_output : str
+            Complete model output, possibly with a synthetic ``<think>`` prefix
+            added by the handler (``needs_redacted_reasoning_prefix=True``).
+
+        Returns
+        -------
+        dict[str, str] | None
+            Same structure as ``HermesReasoningParser.extract_reasoning``.
+        """
+        think_start = model_output.find(self.reasoning_open)
+        if think_start < 0:
+            return {"content": model_output}
+
+        inner_start = think_start + len(self.reasoning_open)
+        inner_text = model_output[inner_start:]
+
+        # Check whether a tool_call appears before the closing </think>
+        think_end = inner_text.find(self.reasoning_close)
+        tool_idx = inner_text.find(self.tool_open)
+
+        if tool_idx >= 0 and (think_end < 0 or tool_idx < think_end):
+            # tool_call appears before (or instead of) </think> — split here.
+            # The reasoning region is terminated by the tool boundary, so any
+            # subsequent </think> marker is consumed (must not surface as content).
+            reasoning_content = inner_text[:tool_idx]
+            after_reasoning_close_content = inner_text[tool_idx:].replace(
+                self.reasoning_close, "", 1
+            )
+            return {
+                "reasoning_content": reasoning_content,
+                "after_reasoning_close_content": after_reasoning_close_content,
+            }
+
+        # Delegate to the parent for the normal </think>-terminated case
+        return super().extract_reasoning(model_output)
+
+    def extract_reasoning_streaming(self, chunk: str) -> tuple[dict[str, str] | str | None, bool]:
+        """Extract reasoning from a streaming chunk, stopping at ``<tool_call>``.
+
+        While accumulating content inside ``<think>`` (both the initial chunk
+        that contains ``<think>`` and subsequent ``FOUND_PREFIX`` chunks), if the
+        combined buffer contains a ``<tool_call>`` tag the parser immediately
+        closes the reasoning region and returns everything from that tag onward
+        as ``after_reasoning_close_content``.
+
+        Parameters
+        ----------
+        chunk : str
+            Chunk of model output to process.
+
+        Returns
+        -------
+        tuple[dict[str, str] | str | None, bool]
+            Same tuple contract as ``HermesReasoningParser.extract_reasoning_streaming``.
+        """
+        if self.state == ReasoningParserState.NORMAL and self.reasoning_open in chunk:
+            # Entering the reasoning region in this chunk — intercept before falling
+            # through to the parent so we can apply tool_open boundary detection.
+            start_idx = chunk.find(self.reasoning_open)
+            inner = chunk[start_idx + len(self.reasoning_open) :]
+
+            # Full tool_call tag visible before </think>?
+            tool_idx = inner.find(self.tool_open)
+            think_end_idx = inner.find(self.reasoning_close)
+
+            if tool_idx >= 0 and (think_end_idx < 0 or tool_idx < think_end_idx):
+                # Whole tool_call tag landed in the same chunk — split immediately.
+                # Strip </think> from the tail (consumed by tool boundary).
+                self.state = ReasoningParserState.NORMAL
+                self.buffer = ""
+                return {
+                    "reasoning_content": inner[:tool_idx],
+                    "after_reasoning_close_content": inner[tool_idx:].replace(
+                        self.reasoning_close, "", 1
+                    ),
+                }, True
+
+            if think_end_idx < 0:
+                # </think> not yet seen — look for a partial tool_open at the tail.
+                overlap = _suffix_prefix_overlap(inner, self.tool_open)
+                if overlap > 0:
+                    safe_text = inner[:-overlap]
+                    self.state = ReasoningParserState.FOUND_PREFIX
+                    self.buffer = inner[-overlap:]
+                    if safe_text:
+                        return {"reasoning_content": safe_text}, False
+                    return None, False
+                # No tool tag risk — let the parent handle it (will set FOUND_PREFIX)
+
+        elif self.state == ReasoningParserState.FOUND_PREFIX:
+            combined = self.buffer + chunk
+
+            # Full tool_call tag visible before </think>?
+            tool_idx = combined.find(self.tool_open)
+            think_end_idx = combined.find(self.reasoning_close)
+
+            if tool_idx >= 0 and (think_end_idx < 0 or tool_idx < think_end_idx):
+                reasoning_content = combined[:tool_idx]
+                # Strip </think> from the tail (consumed by tool boundary).
+                after_reasoning_close_content = combined[tool_idx:].replace(
+                    self.reasoning_close, "", 1
+                )
+                self.buffer = ""
+                self.state = ReasoningParserState.NORMAL
+                return {
+                    "reasoning_content": reasoning_content,
+                    "after_reasoning_close_content": after_reasoning_close_content,
+                }, True
+
+            # No full tool_open yet — guard against partial tag at chunk boundary.
+            # Only apply this guard when </think> is not yet in the combined buffer;
+            # once we can see the close tag the parent logic handles termination.
+            if think_end_idx < 0:
+                overlap = _suffix_prefix_overlap(combined, self.tool_open)
+                if overlap > 0:
+                    safe_text = combined[:-overlap]
+                    self.buffer = combined[-overlap:]
+                    if safe_text:
+                        return {"reasoning_content": safe_text}, False
+                    return None, False
+
+        # Fall through to the parent's implementation for all other cases
+        return super().extract_reasoning_streaming(chunk)

--- a/tests/parsers/test_qwen35_reasoning_tool_parser_conflict.py
+++ b/tests/parsers/test_qwen35_reasoning_tool_parser_conflict.py
@@ -213,7 +213,9 @@ class TestExtractReasoningStreaming:
         if first_token.startswith("<think>"):
             chunks[0] = first_token[len("<think>") :]
         elif full.startswith("<think>"):
-            chunks = [full[len("<think>") :][i : i + 8] for i in range(0, len(full) - len("<think>"), 8)]
+            chunks = [
+                full[len("<think>") :][i : i + 8] for i in range(0, len(full) - len("<think>"), 8)
+            ]
 
         reasoning_results, tool_call_results = _run_streaming(
             chunks, Qwen35ReasoningParser(), FunctionParameterToolParser()

--- a/tests/parsers/test_qwen35_reasoning_tool_parser_conflict.py
+++ b/tests/parsers/test_qwen35_reasoning_tool_parser_conflict.py
@@ -286,6 +286,35 @@ class TestExtractReasoningStreaming:
         )
         assert tool_calls[0]["name"] == "read"
 
+    def test_pure_thinking_delegates_to_parent_across_chunks(self) -> None:
+        """No <tool_call> present: the override must fall through to the
+        parent so a </think> split across chunks is still recognized.
+        """
+        # `<think>thinking</think>summary` — handler prepends <think>, so the
+        # raw chunks look like `['thinking</th', 'ink>summary']`.
+        chunks = ["thinking</th", "ink>summary"]
+        parser = Qwen35ReasoningParser()
+        # First chunk gets the synthetic <think> prefix
+        first = parser.get_reasoning_open() + chunks[0]
+
+        results: list[dict] = []
+        parsed, _ = parser.extract_reasoning_streaming(first)
+        if isinstance(parsed, dict):
+            results.append(parsed)
+        parsed, _ = parser.extract_reasoning_streaming(chunks[1])
+        if isinstance(parsed, dict):
+            results.append(parsed)
+
+        reasoning_text = "".join(r.get("reasoning_content", "") for r in results)
+        after_text = "".join(r.get("after_reasoning_close_content", "") for r in results)
+
+        assert reasoning_text == "thinking", (
+            f"Expected reasoning_content == 'thinking', got: {reasoning_text!r}"
+        )
+        assert after_text == "summary", (
+            f"Expected after_reasoning_close_content == 'summary', got: {after_text!r}"
+        )
+
     def test_chunk_boundary_split_on_tool_open_tag(self) -> None:
         """<tool_call> split across chunks at tag boundary — still detected."""
         # Simulate chunk split mid-tag: '<tool_' | 'call>'

--- a/tests/parsers/test_qwen35_reasoning_tool_parser_conflict.py
+++ b/tests/parsers/test_qwen35_reasoning_tool_parser_conflict.py
@@ -1,0 +1,322 @@
+"""Regression tests for Qwen3.5 reasoning parser absorbing <tool_call> blocks.
+
+Bug: When serving a Qwen3.5 model with tool_call_parser=qwen3_coder and
+reasoning_parser=qwen3_5, the reasoning parser consumes the entire
+<tool_call>...</tool_call> block as reasoning_content, leaving tool_calls empty.
+
+Root cause: HermesReasoningParser.extract_reasoning_streaming accumulates all
+text after <think> until </think> as reasoning. When the model emits
+<tool_call> before </think>, it gets absorbed into reasoning_content.
+
+Fix: Qwen35ReasoningParser overrides extract_reasoning_streaming (and
+extract_reasoning) to detect <tool_call> inside the reasoning region and
+emit it as after_reasoning_close_content instead.
+"""
+
+from __future__ import annotations
+
+from app.parsers.function_parameter import FunctionParameterToolParser
+from app.parsers.qwen3_5 import Qwen35ReasoningParser
+
+# ---------------------------------------------------------------------------
+# Canonical Qwen3.5 tool-call output patterns
+# ---------------------------------------------------------------------------
+
+# Pattern A: tool_call AFTER </think>  (well-formed — should already work)
+PATTERN_A = (
+    "<think>\n\n</think>\n\n"
+    "<tool_call>\n"
+    "<function=read>\n"
+    "<parameter=filePath>\n/tmp/x\n</parameter>\n"
+    "</function>\n"
+    "</tool_call>"
+)
+
+# Pattern B: tool_call BEFORE </think>  (problematic — this is the bug)
+PATTERN_B = (
+    "<think>\n"
+    "<tool_call>\n"
+    "<function=read>\n"
+    "<parameter=filePath>\n/tmp/x\n</parameter>\n"
+    "</function>\n"
+    "</tool_call>\n"
+    "</think>"
+)
+
+# Pattern C: reasoning text, then tool_call, then </think>
+PATTERN_C = (
+    "<think>\n"
+    "I need to read the file.\n"
+    "<tool_call>\n"
+    "<function=read>\n"
+    "<parameter=filePath>\n/tmp/x\n</parameter>\n"
+    "</function>\n"
+    "</tool_call>\n"
+    "</think>"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_streaming(
+    chunks: list[str],
+    reasoning_parser: Qwen35ReasoningParser,
+    tool_parser: FunctionParameterToolParser,
+) -> tuple[list[dict], list[dict]]:
+    """Simulate the handler streaming loop used in mlx_lm.py.
+
+    Returns (reasoning_results, tool_call_results).
+    """
+    reasoning_results: list[dict] = []
+    tool_call_results: list[dict] = []
+
+    after_close: str | None = None
+    is_first_chunk = True
+    rp: Qwen35ReasoningParser | None = reasoning_parser
+    tp: FunctionParameterToolParser | None = tool_parser
+
+    for chunk in chunks:
+        if is_first_chunk and rp and rp.needs_redacted_reasoning_prefix():
+            chunk = rp.get_reasoning_open() + chunk
+            is_first_chunk = False
+
+        if rp:
+            parsed, is_complete = rp.extract_reasoning_streaming(chunk)
+            if parsed and isinstance(parsed, dict):
+                reasoning_results.append(parsed)
+                after_close = parsed.get("after_reasoning_close_content")
+            if is_complete:
+                rp = None
+            if after_close:
+                chunk = after_close
+                after_close = None
+            else:
+                continue
+
+        if tp:
+            parsed, is_complete = tp.extract_tool_calls_streaming(chunk)
+            if parsed and isinstance(parsed, dict):
+                tool_call_results.append(parsed)
+            if is_complete:
+                tp = None
+
+    return reasoning_results, tool_call_results
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractReasoningNonStreaming:
+    """Non-streaming path: extract_reasoning must not absorb <tool_call>."""
+
+    def test_pattern_a_tool_after_think(self) -> None:
+        """tool_call after </think> — after_reasoning_close_content should contain it."""
+        parser = Qwen35ReasoningParser()
+        result = parser.extract_reasoning(PATTERN_A)
+        assert result is not None
+        assert "reasoning_content" in result
+        after = result.get("after_reasoning_close_content", "")
+        assert "<tool_call>" in after, (
+            f"Expected <tool_call> in after_reasoning_close_content, got: {after!r}"
+        )
+        assert "reasoning_content" not in result.get("reasoning_content", "") or (
+            "<tool_call>" not in result["reasoning_content"]
+        ), f"<tool_call> must not appear in reasoning_content, got: {result['reasoning_content']!r}"
+
+    def test_pattern_b_tool_inside_think(self) -> None:
+        """tool_call inside <think>...</think> — must NOT be absorbed as reasoning."""
+        parser = Qwen35ReasoningParser()
+        result = parser.extract_reasoning(PATTERN_B)
+        assert result is not None
+        # The <tool_call> block must not land in reasoning_content
+        reasoning = result.get("reasoning_content", "")
+        assert "<tool_call>" not in reasoning, (
+            f"<tool_call> was absorbed into reasoning_content: {reasoning!r}"
+        )
+        # It must be available for downstream tool parsing
+        after = result.get("after_reasoning_close_content", "")
+        assert "<tool_call>" in after, (
+            f"Expected <tool_call> in after_reasoning_close_content, got: {after!r}"
+        )
+        # The </think> close marker is consumed by the tool boundary and must
+        # not leak into the after-close content (which is fed to the tool parser
+        # and would otherwise surface as stray content in the response).
+        assert "</think>" not in after, (
+            f"</think> leaked into after_reasoning_close_content: {after!r}"
+        )
+
+    def test_pattern_c_reasoning_then_tool_inside_think(self) -> None:
+        """Reasoning text + tool_call inside <think> — split at tool_call boundary."""
+        parser = Qwen35ReasoningParser()
+        result = parser.extract_reasoning(PATTERN_C)
+        assert result is not None
+        reasoning = result.get("reasoning_content", "")
+        assert "<tool_call>" not in reasoning, (
+            f"<tool_call> was absorbed into reasoning_content: {reasoning!r}"
+        )
+        after = result.get("after_reasoning_close_content", "")
+        assert "<tool_call>" in after, (
+            f"Expected <tool_call> in after_reasoning_close_content, got: {after!r}"
+        )
+        assert "</think>" not in after, (
+            f"</think> leaked into after_reasoning_close_content: {after!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Streaming tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractReasoningStreaming:
+    """Streaming path: extract_reasoning_streaming must not absorb <tool_call>."""
+
+    def test_pattern_b_single_chunk(self) -> None:
+        """Entire PATTERN_B in one chunk — tool_call not absorbed."""
+        parser = Qwen35ReasoningParser()
+        # Prepend <think> since needs_redacted_reasoning_prefix=True
+        chunk = parser.get_reasoning_open() + PATTERN_B.removeprefix("<think>")
+        results = []
+        is_complete = False
+        parsed, is_complete = parser.extract_reasoning_streaming(chunk)
+        if parsed:
+            results.append(parsed)
+
+        reasoning_text = "".join(
+            r.get("reasoning_content", "") for r in results if isinstance(r, dict)
+        )
+        after_text = "".join(
+            r.get("after_reasoning_close_content", "") for r in results if isinstance(r, dict)
+        )
+        assert "<tool_call>" not in reasoning_text, (
+            f"<tool_call> absorbed into reasoning_content: {reasoning_text!r}"
+        )
+        assert "<tool_call>" in after_text, (
+            f"<tool_call> not in after_reasoning_close_content: {after_text!r}"
+        )
+        assert "</think>" not in after_text, (
+            f"</think> leaked into after_reasoning_close_content: {after_text!r}"
+        )
+
+    def test_full_pipeline_pattern_a(self) -> None:
+        """Pattern A (tool after </think>) — end-to-end streaming pipeline succeeds."""
+        # Split at token boundaries to simulate real streaming
+        full = PATTERN_A
+        chunks = [full[i : i + 8] for i in range(0, len(full), 8)]
+        # Remove the leading <think> since the handler prepends it
+        first_token = chunks[0]
+        if first_token.startswith("<think>"):
+            chunks[0] = first_token[len("<think>") :]
+        elif full.startswith("<think>"):
+            chunks = [full[len("<think>") :][i : i + 8] for i in range(0, len(full) - len("<think>"), 8)]
+
+        reasoning_results, tool_call_results = _run_streaming(
+            chunks, Qwen35ReasoningParser(), FunctionParameterToolParser()
+        )
+
+        tool_calls = []
+        for r in tool_call_results:
+            tool_calls.extend(r.get("tool_calls", []))
+
+        assert len(tool_calls) == 1, f"Expected 1 tool call, got: {tool_call_results}"
+        assert tool_calls[0]["name"] == "read"
+
+    def test_full_pipeline_pattern_b(self) -> None:
+        """Pattern B (tool inside <think>) — tool_call must reach tool parser."""
+        full = PATTERN_B
+        # Strip the leading <think> — handler re-adds it
+        inner = full[len("<think>") :]
+        chunks = [inner[i : i + 6] for i in range(0, len(inner), 6)]
+
+        reasoning_results, tool_call_results = _run_streaming(
+            chunks, Qwen35ReasoningParser(), FunctionParameterToolParser()
+        )
+
+        # tool_call must not be swallowed as reasoning
+        reasoning_text = "".join(
+            r.get("reasoning_content", "") for r in reasoning_results if isinstance(r, dict)
+        )
+        assert "<tool_call>" not in reasoning_text, (
+            f"<tool_call> absorbed as reasoning: {reasoning_text!r}"
+        )
+
+        tool_calls = []
+        for r in tool_call_results:
+            tool_calls.extend(r.get("tool_calls", []))
+
+        assert len(tool_calls) == 1, (
+            f"Expected 1 tool call, got tool_call_results={tool_call_results!r}"
+        )
+        assert tool_calls[0]["name"] == "read"
+
+    def test_full_pipeline_pattern_c(self) -> None:
+        """Pattern C (reasoning + tool inside <think>) — reasoning captured, tool parsed."""
+        full = PATTERN_C
+        inner = full[len("<think>") :]
+        chunks = [inner[i : i + 5] for i in range(0, len(inner), 5)]
+
+        reasoning_results, tool_call_results = _run_streaming(
+            chunks, Qwen35ReasoningParser(), FunctionParameterToolParser()
+        )
+
+        reasoning_text = "".join(
+            r.get("reasoning_content", "") for r in reasoning_results if isinstance(r, dict)
+        )
+        assert "<tool_call>" not in reasoning_text, (
+            f"<tool_call> absorbed as reasoning: {reasoning_text!r}"
+        )
+        # Some reasoning text should have been captured
+        assert len(reasoning_text) > 0 or any(
+            "reasoning_content" in r for r in reasoning_results if isinstance(r, dict)
+        )
+
+        tool_calls = []
+        for r in tool_call_results:
+            tool_calls.extend(r.get("tool_calls", []))
+
+        assert len(tool_calls) == 1, (
+            f"Expected 1 tool call, got tool_call_results={tool_call_results!r}"
+        )
+        assert tool_calls[0]["name"] == "read"
+
+    def test_chunk_boundary_split_on_tool_open_tag(self) -> None:
+        """<tool_call> split across chunks at tag boundary — still detected."""
+        # Simulate chunk split mid-tag: '<tool_' | 'call>'
+        inner = (
+            "\n"
+            "I need to read the file.\n"
+            "<tool_call>\n"
+            "<function=read>\n"
+            "<parameter=filePath>\n/tmp/x\n</parameter>\n"
+            "</function>\n"
+            "</tool_call>\n"
+            "</think>"
+        )
+        # Split at the '<tool_' boundary
+        split_idx = inner.index("<tool_call>") + len("<tool_")
+        chunks = [inner[:split_idx], inner[split_idx:]]
+
+        reasoning_results, tool_call_results = _run_streaming(
+            chunks, Qwen35ReasoningParser(), FunctionParameterToolParser()
+        )
+
+        reasoning_text = "".join(
+            r.get("reasoning_content", "") for r in reasoning_results if isinstance(r, dict)
+        )
+        assert "<tool_call>" not in reasoning_text, (
+            f"<tool_call> absorbed as reasoning: {reasoning_text!r}"
+        )
+
+        tool_calls = []
+        for r in tool_call_results:
+            tool_calls.extend(r.get("tool_calls", []))
+
+        assert len(tool_calls) == 1, (
+            f"Expected 1 tool call, got tool_call_results={tool_call_results!r}"
+        )
+        assert tool_calls[0]["name"] == "read"


### PR DESCRIPTION
## Problem

When a Qwen3.5 model is served with `reasoning_parser: qwen3_5` and
`tool_call_parser: qwen3_coder`, the reasoning parser absorbs the entire
`<tool_call>…</tool_call>` block into `reasoning_content`. The completion comes
back with an empty `tool_calls` array, and agent-style clients (OpenCode,
Openclaw, etc.) stall until their 300s tool-call timeout.

The model is emitting the correct Qwen3.5 Coder format; the parser just never
yields control before `</think>` closes.

Minimal reproduction (non-stream, `enable_thinking=True` which is the default):

Model output:

    <think>
    The user wants me to read /tmp/probe.txt.
    <tool_call>
    <function=read>
    <parameter=filePath>
    /tmp/probe.txt
    </parameter>
    </function>
    </tool_call>
    </think>

Expected: `choices[0].message.tool_calls[0]` holds the `read` call.
Actual: `reasoning_content` contains the full `<tool_call>` block verbatim and
`tool_calls` is empty.

Root cause: `HermesReasoningParser.extract_reasoning_streaming` sits in
`FOUND_PREFIX` from `<think>` to `</think>` and keeps every token in
`reasoning_content`, so the tool parser never sees `<tool_call>`. The
`tool_hint_present` / `reasoning_passthrough_for_tool` guard added in #218 only
fires once the tool parser is past NORMAL, which cannot happen while the
reasoning parser is still holding the text. Non-stream follows the same shape:
the `<think>…</think>` DOTALL regex greedily swallows any `<tool_call>` that
appears inside the think block.

## Solution

Override `extract_reasoning` and `extract_reasoning_streaming` in
`Qwen35ReasoningParser` so that a `<tool_call>` opener inside the reasoning
region is treated as an implicit reasoning close:

- Non-stream: if `<tool_call>` appears before `</think>`, split the buffer at
  the opener — everything before becomes `reasoning_content`, the `<tool_call>`
  block and anything after becomes `after_reasoning_close_content`. The
  trailing `</think>` marker is consumed by the tool boundary and stripped from
  the after-close content so it does not surface as stray content.
- Streaming: in both NORMAL (the chunk that introduces `<think>`) and
  `FOUND_PREFIX` states, scan for `<tool_call>` and flush the tool region out
  of reasoning as soon as the opener is complete. A suffix/prefix overlap
  guard keeps a partial `<tool_` across chunk boundaries without emitting it.

Normal cases (`</think>` closes cleanly before any tool call) still go through
the parent implementation untouched, so existing Qwen3 / Qwen3.5 flows with
thinking-only responses are unaffected.

The shape follows the per-parser streaming override introduced in #277 for
Gemma4.

## Usage

No config changes required. The previously-recommended workaround of forcing
`chat_template_file: qwen3.5-no-think.jinja` (which suppressed thinking
entirely) is no longer necessary:

```yaml
- model_path: mlx-community/Qwen3.5-9B-MLX-4bit
  tool_call_parser: qwen3_coder
  reasoning_parser: qwen3_5
```

`chat_template_kwargs.enable_thinking=false` continues to short-circuit the
reasoning parser for clients that want to opt out explicitly.

## Tests

- New regression suite `tests/parsers/test_qwen35_reasoning_tool_parser_conflict.py`
  covers three non-streaming patterns (tool after `</think>`, tool inside
  `<think>`, reasoning + tool inside `<think>`) and five streaming patterns
  including a `<tool_` token split across chunk boundaries. The non-streaming
  suite also asserts the `</think>` marker does not leak into the after-close
  content.
- `pytest tests/parsers/ -q` → 37 passed, no regressions.
- Verified end-to-end on `mlx-community/Qwen3.5-9B-6bit` with OpenCode: the
  client now receives `tool_calls` and executes the tool instead of timing
  out on reasoning-only output.