### PR TITLE
feat: add disk-backed prompt KV cache support

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ LM-specific memory and batching options:
 | `--prefill-step-size` | `2048` | Tokens per prefill step |
 | `--prompt-cache-size` | `10` | Retained prompt KV cache entries |
 | `--max-bytes` | unbounded | Prompt KV cache byte budget |
+| `--prompt-cache-dir` | temp dir | Directory for disk-backed prompt KV cache payloads |
 | `--kv-bits` | unset | KV cache quantization bits, usually `4` or `8` |
 | `--kv-group-size` | `64` | KV quantization group size |
 | `--quantized-kv-start` | `0` | Token step where KV quantization starts |
@@ -292,7 +293,7 @@ Important YAML keys:
 |-----|-------|
 | `model_path`, `model_type`, `served_model_name` | Model identity and routing |
 | `context_length` | LM/multimodal context length |
-| `prompt_cache_size`, `prompt_cache_max_bytes` | Prompt KV cache limits |
+| `prompt_cache_size`, `prompt_cache_max_bytes`, `prompt_cache_dir` | Prompt KV cache limits and disk location |
 | `batch_completion_size`, `batch_prefill_size`, `batch_prefill_step_size` | Continuous batching limits |
 | `kv_bits`, `kv_group_size`, `quantized_kv_start` | KV cache quantization |
 | `default_max_tokens` | Default generated tokens |

--- a/app/cli.py
+++ b/app/cli.py
@@ -261,6 +261,15 @@ def cli():
     help="Maximum total bytes retained by prompt KV caches before eviction. Only works with language models (lm).",
 )
 @click.option(
+    "--prompt-cache-dir",
+    default=None,
+    type=click.Path(file_okay=False, dir_okay=True, path_type=str),
+    help=(
+        "Directory for disk-backed prompt KV cache payloads. "
+        "Defaults to a process-local temporary directory."
+    ),
+)
+@click.option(
     "--draft-model-path",
     default=None,
     type=str,
@@ -393,6 +402,7 @@ def launch(
     debug,
     prompt_cache_size,
     prompt_cache_max_bytes,
+    prompt_cache_dir,
     draft_model_path,
     num_draft_tokens,
     kv_bits,
@@ -467,6 +477,7 @@ def launch(
         debug=debug,
         prompt_cache_size=prompt_cache_size,
         prompt_cache_max_bytes=prompt_cache_max_bytes,
+        prompt_cache_dir=prompt_cache_dir,
         draft_model_path=draft_model_path,
         num_draft_tokens=num_draft_tokens,
         kv_bits=kv_bits,

--- a/app/config.py
+++ b/app/config.py
@@ -56,6 +56,7 @@ class MLXServerConfig:
     debug: bool = False
     prompt_cache_size: int = 10
     prompt_cache_max_bytes: int = 1 << 63
+    prompt_cache_dir: str | None = None
     draft_model_path: str | None = None
     num_draft_tokens: int = 2
 
@@ -194,6 +195,7 @@ class MLXServerConfig:
             debug=self.debug,
             prompt_cache_size=self.prompt_cache_size,
             prompt_cache_max_bytes=self.prompt_cache_max_bytes,
+            prompt_cache_dir=self.prompt_cache_dir,
             draft_model_path=self.draft_model_path,
             num_draft_tokens=self.num_draft_tokens,
             kv_bits=self.kv_bits,
@@ -289,6 +291,7 @@ class ModelEntryConfig:
     debug: bool = False
     prompt_cache_size: int = 10
     prompt_cache_max_bytes: int = 1 << 63
+    prompt_cache_dir: str | None = None
     draft_model_path: str | None = None
     num_draft_tokens: int = 2
     kv_bits: int | None = None

--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -130,6 +130,7 @@ class MLXLMHandler:
         debug: bool = False,
         prompt_cache_size: int = 10,
         prompt_cache_max_bytes: int = 1 << 63,
+        prompt_cache_dir: str | None = None,
         kv_bits: int | None = None,
         kv_group_size: int = 64,
         quantized_kv_start: int = 0,
@@ -169,6 +170,9 @@ class MLXLMHandler:
             Maximum number of prompt KV cache entries to store. Default is 10.
         prompt_cache_max_bytes : int
             Maximum total bytes retained by prompt KV caches before eviction.
+        prompt_cache_dir : str | None
+            Directory used for disk-backed prompt KV cache payloads. If None,
+            a process-local temporary directory is used.
         kv_bits : int | None
             Number of bits for KV cache quantization. None disables quantization.
         kv_group_size : int
@@ -215,6 +219,7 @@ class MLXLMHandler:
         self.prompt_cache = LRUPromptCache(
             max_size=prompt_cache_size,
             max_bytes=prompt_cache_max_bytes,
+            cache_dir=prompt_cache_dir,
         )
         self.message_converter = MessageConverterManager.create_converter(
             converter_name=message_converter,
@@ -1340,6 +1345,8 @@ class MLXLMHandler:
                 self._batch_scheduler = None
             if hasattr(self, "inference_worker"):
                 self.inference_worker.stop()
+            if hasattr(self, "prompt_cache"):
+                self.prompt_cache.close()
 
             # Force garbage collection
             gc.collect()

--- a/app/main.py
+++ b/app/main.py
@@ -113,6 +113,8 @@ def print_startup_banner(config_args: MLXServerConfig) -> None:
         logger.info(
             f"💾 Prompt Cache Max Bytes: {_format_bytes(config_args.prompt_cache_max_bytes)}"
         )
+        if getattr(config_args, "prompt_cache_dir", None):
+            logger.info(f"💾 Prompt Cache Dir: {config_args.prompt_cache_dir}")
         logger.info(
             f"🧵 Batch Scheduler: decode={config_args.batch_completion_size}, "
             f"prefill={config_args.batch_prefill_size}, "

--- a/app/server.py
+++ b/app/server.py
@@ -319,6 +319,7 @@ def create_handler_from_config(model_cfg: ModelEntryConfig) -> Any:
             debug=model_cfg.debug,
             prompt_cache_size=model_cfg.prompt_cache_size,
             prompt_cache_max_bytes=model_cfg.prompt_cache_max_bytes,
+            prompt_cache_dir=model_cfg.prompt_cache_dir,
             draft_model_path=model_cfg.draft_model_path,
             num_draft_tokens=model_cfg.num_draft_tokens,
             kv_bits=model_cfg.kv_bits,

--- a/app/utils/dill.py
+++ b/app/utils/dill.py
@@ -145,6 +145,11 @@ def dump(obj: Any, file: BinaryIO) -> None:
     Pickler(file, recurse=True).dump(obj)
 
 
+def load(file: BinaryIO) -> Any:
+    """Load a pickled object from a file."""
+    return dill.load(file)
+
+
 def dumps(obj: Any) -> bytes:
     """Pickle an object to a string."""
     file = BytesIO()

--- a/app/utils/prompt_cache.py
+++ b/app/utils/prompt_cache.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 from collections import deque
-import copy
 from dataclasses import dataclass
+import gc
+from pathlib import Path
+import pickle
+import shutil
+import tempfile
 from typing import Any
+import uuid
 
 from loguru import logger
 from mlx_lm.models.cache import can_trim_prompt_cache, trim_prompt_cache
+
+from . import dill
 
 
 @dataclass
@@ -130,12 +137,13 @@ class PromptTrie:
 
 
 class LRUPromptCache:
-    """LRU cache for MLX prompt KV caches.
+    """Disk-backed LRU cache for MLX prompt KV caches.
 
     The cache stores token sequences in a trie so it can efficiently find exact
     matches, shorter prefixes, and longer cached sequences that can be trimmed
     down to a requested prefix. Entries are evicted using an LRU policy with
-    optional byte-based trimming.
+    optional byte-based trimming. Only metadata is kept in memory; prompt-cache
+    matrices are serialized to disk on insert and loaded only on cache hits.
 
     Parameters
     ----------
@@ -144,15 +152,19 @@ class LRUPromptCache:
     max_bytes : int, optional
         Maximum total bytes to retain across cached prompt caches, by default a
         practically unbounded value.
+    cache_dir : str | Path | None, optional
+        Directory used to store serialized prompt caches. A process-local
+        temporary directory is created when omitted.
     """
 
     @dataclass
     class CacheEntry:
-        """Stored prompt cache entry."""
+        """Stored prompt cache metadata."""
 
-        prompt_cache: list[Any]
+        file_path: Path
         nbytes: int
         cache_type: str
+        trimmable: bool
 
     class CacheOrder:
         """Track cache recency with priority-based eviction."""
@@ -198,9 +210,25 @@ class LRUPromptCache:
             """Return the number of entries of the given type."""
             return len(self._lrus[cache_type])
 
-    def __init__(self, max_size: int = 10, max_bytes: int = 1 << 63) -> None:
+        def pop_from_type(self, cache_type: str) -> tuple[int, ...]:
+            """Pop the oldest entry for the given cache type."""
+            return self._lrus[cache_type].popleft()
+
+    def __init__(
+        self,
+        max_size: int = 10,
+        max_bytes: int = 1 << 63,
+        cache_dir: str | Path | None = None,
+    ) -> None:
         self.max_size = max_size
         self.max_bytes = max_bytes
+        if cache_dir is None:
+            self.cache_dir = Path(tempfile.mkdtemp(prefix="mlx-openai-prompt-cache-"))
+            self._owns_cache_dir = True
+        else:
+            self.cache_dir = Path(cache_dir).expanduser()
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+            self._owns_cache_dir = False
         self._trie = PromptTrie()
         self._lru = self.CacheOrder()
         self._n_bytes = 0
@@ -212,6 +240,101 @@ class LRUPromptCache:
     @property
     def nbytes(self) -> int:
         return self._n_bytes
+
+    def _cache_file_path(self) -> Path:
+        """Return a unique path for a serialized cache entry."""
+        return self.cache_dir / f"{uuid.uuid4().hex}.pkl"
+
+    def _write_cache_to_disk(self, prompt_cache: list[Any]) -> Path:
+        """Serialize a prompt cache to disk and return its final path.
+
+        Parameters
+        ----------
+        prompt_cache : list[Any]
+            MLX prompt-cache object list to serialize.
+
+        Returns
+        -------
+        Path
+            Path to the completed cache payload.
+
+        Raises
+        ------
+        OSError
+            If the cache directory or file cannot be written.
+        pickle.PickleError
+            If the prompt cache cannot be serialized.
+        """
+        file_path = self._cache_file_path()
+        temp_path = file_path.with_suffix(".tmp")
+        with temp_path.open("wb") as f:
+            dill.dump(prompt_cache, f)
+        temp_path.replace(file_path)
+        return file_path
+
+    def _load_cache_from_disk(self, entry: CacheEntry) -> list[Any]:
+        """Deserialize a prompt cache entry from disk."""
+        with entry.file_path.open("rb") as f:
+            cache = dill.load(f)
+        if not isinstance(cache, list):
+            msg = f"Prompt cache payload at {entry.file_path} is not a list"
+            raise TypeError(msg)
+        return cache
+
+    def _delete_entry_file(self, entry: CacheEntry) -> None:
+        """Delete a serialized cache file, logging best-effort failures."""
+        try:
+            entry.file_path.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning(f"Failed to delete prompt cache file {entry.file_path}: {exc!s}")
+
+    def _remove_entry_accounting(self, entry: CacheEntry) -> None:
+        """Subtract an entry from in-memory byte accounting."""
+        self._n_bytes -= entry.nbytes
+        self._n_bytes_by_type[entry.cache_type] -= entry.nbytes
+
+    def _evict_tokens(self, tokens: tuple[int, ...]) -> None:
+        """Evict one token sequence and its on-disk payload."""
+        evicted_entry = self._trie.pop(list(tokens))
+        self._remove_entry_accounting(evicted_entry)
+        self._delete_entry_file(evicted_entry)
+
+    def _invalidate_tokens(self, tokens: list[int], entry: CacheEntry) -> None:
+        """Remove a corrupt or missing cache entry from all indexes."""
+        try:
+            self._trie.pop(tokens)
+        except (KeyError, IndexError):
+            pass
+        self._lru.remove(tuple(tokens))
+        self._remove_entry_accounting(entry)
+        self._delete_entry_file(entry)
+
+    def _try_load_cache(self, tokens: list[int], entry: CacheEntry) -> list[Any] | None:
+        """Load an entry and invalidate it if the on-disk payload is unusable."""
+        try:
+            return self._load_cache_from_disk(entry)
+        except (
+            OSError,
+            EOFError,
+            TypeError,
+            ValueError,
+            AttributeError,
+            pickle.PickleError,
+        ) as exc:
+            logger.warning(f"Failed to load prompt cache from {entry.file_path}: {exc!s}")
+            self._invalidate_tokens(tokens, entry)
+            self._release_evicted_memory()
+            return None
+
+    def _release_evicted_memory(self) -> None:
+        """Ask Python and MLX to release memory after cache entries are evicted."""
+        gc.collect()
+        try:
+            import mlx.core as mx  # noqa: PLC0415
+
+            mx.clear_cache()
+        except (ImportError, RuntimeError) as exc:
+            logger.debug(f"Could not clear MLX cache after prompt-cache eviction: {exc!s}")
 
     def fetch_nearest_cache(
         self,
@@ -228,21 +351,27 @@ class LRUPromptCache:
         result = self._trie.search(tokens_ids)
         if result.exact is not None:
             cache_entry = self._trie.get(result.exact)
-            return copy.deepcopy(cache_entry.prompt_cache), []
+            cache = self._try_load_cache(result.exact, cache_entry)
+            if cache is not None:
+                return cache, []
+            return None, tokens_ids
 
         short_length = len(result.shorter) if result.shorter is not None else 0
         if result.longer is not None and result.common_prefix > short_length:
             cache_entry = self._trie.get(result.longer)
-            if can_trim_prompt_cache(cache_entry.prompt_cache):
-                cache = copy.deepcopy(cache_entry.prompt_cache)
-                prefix = min(len(tokens_ids) - 1, result.common_prefix)
-                num_to_trim = len(result.longer) - prefix
-                trim_prompt_cache(cache, num_to_trim)
-                return cache, tokens_ids[prefix:]
+            if cache_entry.trimmable:
+                cache = self._try_load_cache(result.longer, cache_entry)
+                if cache is not None:
+                    prefix = min(len(tokens_ids) - 1, result.common_prefix)
+                    num_to_trim = len(result.longer) - prefix
+                    trim_prompt_cache(cache, num_to_trim)
+                    return cache, tokens_ids[prefix:]
 
         if short_length > 0:
             cache_entry = self._trie.get(result.shorter)
-            return copy.deepcopy(cache_entry.prompt_cache), tokens_ids[short_length:]
+            cache = self._try_load_cache(result.shorter, cache_entry)
+            if cache is not None:
+                return cache, tokens_ids[short_length:]
 
         return None, tokens_ids
 
@@ -268,7 +397,10 @@ class LRUPromptCache:
 
         # Make the cache entry
         entry = self.CacheEntry(
-            prompt_cache, sum(getattr(c, "nbytes", 0) for c in prompt_cache), cache_type
+            self._write_cache_to_disk(prompt_cache),
+            sum(getattr(c, "nbytes", 0) for c in prompt_cache),
+            cache_type,
+            can_trim_prompt_cache(prompt_cache),
         )
 
         # Insert into the trie and update the byte counter and lru position
@@ -276,31 +408,29 @@ class LRUPromptCache:
         self._n_bytes_by_type[cache_type] += entry.nbytes
         prev = self._trie.add(tokens_ids, entry)
         if prev is not None:
-            self._n_bytes -= prev.nbytes
-            self._n_bytes_by_type[prev.cache_type] -= prev.nbytes
+            self._remove_entry_accounting(prev)
+            self._delete_entry_file(prev)
             self._lru.remove(tokens_tuple)
         self._lru.push(tokens_tuple, cache_type)
 
         # If it is a trimmable cache remove all prefixes cause they just take
         # space
-        if can_trim_prompt_cache(prompt_cache):
+        if entry.trimmable:
             for prefix_len, removed_entry in self._trie.pop_prefixes(tokens_ids):
-                self._n_bytes -= removed_entry.nbytes
-                self._n_bytes_by_type[removed_entry.cache_type] -= removed_entry.nbytes
+                self._remove_entry_accounting(removed_entry)
+                self._delete_entry_file(removed_entry)
                 self._lru.remove(tuple(tokens_ids[:prefix_len]))
 
         # Ensure we match the constraints
         if len(self._lru) > self.max_size:
             evicted = self._lru.pop()
-            evicted_entry = self._trie.pop(list(evicted))
-            self._n_bytes -= evicted_entry.nbytes
-            self._n_bytes_by_type[evicted_entry.cache_type] -= evicted_entry.nbytes
+            self._evict_tokens(evicted)
 
         while self._n_bytes > self.max_bytes:
             evicted = self._lru.pop()
-            evicted_entry = self._trie.pop(list(evicted))
-            self._n_bytes -= evicted_entry.nbytes
-            self._n_bytes_by_type[evicted_entry.cache_type] -= evicted_entry.nbytes
+            self._evict_tokens(evicted)
+
+        self._release_evicted_memory()
 
     def trim_to(self, *, n_sequences: int | None = None, n_bytes: int | None = None) -> None:
         """Trim the cache down to sequence and/or byte limits."""
@@ -309,15 +439,26 @@ class LRUPromptCache:
 
         while len(self._lru) > max_sequences:
             evicted = self._lru.pop()
-            evicted_entry = self._trie.pop(list(evicted))
-            self._n_bytes -= evicted_entry.nbytes
-            self._n_bytes_by_type[evicted_entry.cache_type] -= evicted_entry.nbytes
+            self._evict_tokens(evicted)
 
         while self._n_bytes > max_bytes:
             evicted = self._lru.pop()
-            evicted_entry = self._trie.pop(list(evicted))
-            self._n_bytes -= evicted_entry.nbytes
-            self._n_bytes_by_type[evicted_entry.cache_type] -= evicted_entry.nbytes
+            self._evict_tokens(evicted)
+
+        self._release_evicted_memory()
+
+    def clear(self) -> None:
+        """Remove all tracked cache entries and serialized payloads."""
+        for cache_type in self._lru.ordering:
+            while self._lru.count_by_type(cache_type):
+                self._evict_tokens(self._lru.pop_from_type(cache_type))
+        self._release_evicted_memory()
+
+    def close(self) -> None:
+        """Clear entries and remove the owned temporary cache directory."""
+        self.clear()
+        if self._owns_cache_dir:
+            shutil.rmtree(self.cache_dir, ignore_errors=True)
 
     def stats_by_type(self) -> dict[str, dict[str, int]]:
         """Return per-type sequence count and byte usage."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "aiofiles>=25,<26",
   "av>=16.0.1,<17",
   "click>=8.2.1,<8.4",
+  "dill>=0.4,<0.5",
   "fastapi>=0.115.14,<0.130",
   "httpx>=0.28,<1",
   "json_repair>=0.52.1,<0.60",
@@ -47,6 +48,7 @@ dependencies = [
   "torchvision>=0.23.0,<0.30",
   "mflux>=0.17.4,<0.18",
   "uvicorn>=0.35.0,<0.40",
+  "xxhash>=3.6,<4",
 ]
 
 [dependency-groups]

--- a/tests/test_prompt_cache_disk.py
+++ b/tests/test_prompt_cache_disk.py
@@ -1,0 +1,108 @@
+"""Tests for disk-backed prompt KV cache retention."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+import sys
+import types
+from typing import Any
+
+
+class _FakeCacheLayer:
+    """Serializable fake cache layer with MLX-like byte accounting."""
+
+    def __init__(self, value: str, nbytes: int = 10) -> None:
+        self.value = value
+        self.nbytes = nbytes
+
+
+def _load_prompt_cache_module(monkeypatch: Any, *, trimmable: bool) -> Any:
+    """Import ``app.utils.prompt_cache`` with a fake MLX cache module."""
+    fake_mlx_lm = types.ModuleType("mlx_lm")
+    fake_models = types.ModuleType("mlx_lm.models")
+    fake_cache = types.ModuleType("mlx_lm.models.cache")
+
+    fake_cache.can_trim_prompt_cache = lambda _cache: trimmable
+
+    def trim_prompt_cache(cache: list[Any], n: int) -> int:
+        del cache[-n:]
+        return n
+
+    fake_cache.trim_prompt_cache = trim_prompt_cache
+    fake_models.cache = fake_cache
+    fake_mlx_lm.models = fake_models
+
+    monkeypatch.setitem(sys.modules, "mlx_lm", fake_mlx_lm)
+    monkeypatch.setitem(sys.modules, "mlx_lm.models", fake_models)
+    monkeypatch.setitem(sys.modules, "mlx_lm.models.cache", fake_cache)
+    sys.modules.pop("app.utils.prompt_cache", None)
+    module = importlib.import_module("app.utils.prompt_cache")
+    return importlib.reload(module)
+
+
+def test_prompt_cache_payload_is_written_to_disk(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    """LRU entries should retain metadata in memory and payloads on disk."""
+    prompt_cache_module = _load_prompt_cache_module(monkeypatch, trimmable=False)
+    cache = prompt_cache_module.LRUPromptCache(max_size=10, cache_dir=tmp_path)
+
+    cache.insert_cache([1, 2, 3], [_FakeCacheLayer("a")])
+
+    entry = cache._trie.get([1, 2, 3])
+    assert not hasattr(entry, "prompt_cache")
+    assert entry.file_path.exists()
+
+    result, rest = cache.fetch_nearest_cache([1, 2, 3])
+
+    assert rest == []
+    assert result is not None
+    assert result[0].value == "a"
+
+
+def test_prompt_cache_eviction_deletes_disk_payload(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    """Evicting an LRU entry should remove its serialized cache file."""
+    prompt_cache_module = _load_prompt_cache_module(monkeypatch, trimmable=False)
+    cache = prompt_cache_module.LRUPromptCache(max_size=1, cache_dir=tmp_path)
+
+    cache.insert_cache([1], [_FakeCacheLayer("old")])
+    old_path = cache._trie.get([1]).file_path
+
+    cache.insert_cache([2], [_FakeCacheLayer("new")])
+
+    assert not old_path.exists()
+    assert cache.fetch_nearest_cache([1]) == (None, [1])
+    result, rest = cache.fetch_nearest_cache([2])
+    assert rest == []
+    assert result is not None
+    assert result[0].value == "new"
+
+
+def test_prompt_cache_longer_hit_loads_and_trims_from_disk(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    """Longer trimmable hits should load the payload only for the hit path."""
+    prompt_cache_module = _load_prompt_cache_module(monkeypatch, trimmable=True)
+    cache = prompt_cache_module.LRUPromptCache(max_size=10, cache_dir=tmp_path)
+
+    cache.insert_cache(
+        [1, 2, 3, 4],
+        [
+            _FakeCacheLayer("one"),
+            _FakeCacheLayer("two"),
+            _FakeCacheLayer("three"),
+            _FakeCacheLayer("four"),
+        ],
+    )
+
+    result, rest = cache.fetch_nearest_cache([1, 2, 9])
+
+    assert rest == [9]
+    assert result is not None
+    assert [layer.value for layer in result] == ["one", "two"]


### PR DESCRIPTION
feat: add disk-backed prompt cache storage

## Summary
This PR moves MLX prompt KV cache payloads out of memory and onto disk while keeping trie/LRU metadata in memory. The change reduces resident memory pressure for cached prompts and makes cache retention more predictable.

## What Changed
- Added disk-backed prompt cache persistence in `app/utils/prompt_cache.py`
- Serialized cache payloads on insert and loaded them only on cache hits
- Cleaned up serialized payloads during eviction, trimming, and shutdown
- Added a configurable `--prompt-cache-dir` CLI option
- Threaded `prompt_cache_dir` through server config and handler wiring
- Added `dill` as a dependency for cache serialization
- Documented the new option in `README.md`
- Added regression coverage for disk write, eviction cleanup, and trim/load behavior

## Notes
- If `--prompt-cache-dir` is not provided, the server uses a process-local temporary directory.
