### PR TITLE
Fix/generation config sampling defaults

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -542,6 +542,10 @@ def refine_chat_completion_request(
         request.presence_penalty = _get_sampling_default(
             handler, "default_presence_penalty", "DEFAULT_PRESENCE_PENALTY", _parse_env_float
         )
+    if request.frequency_penalty is None:
+        request.frequency_penalty = _get_sampling_default(
+            handler, "default_frequency_penalty", "DEFAULT_FREQUENCY_PENALTY", _parse_env_float
+        )
     if request.repetition_context_size is None:
         request.repetition_context_size = _get_sampling_default(
             handler,

--- a/app/cli.py
+++ b/app/cli.py
@@ -335,44 +335,44 @@ def cli():
 # Sampling parameters (defaults used when API request omits them)
 @click.option(
     "--max-tokens",
-    default=100000,
+    default=None,
     type=int,
-    help="Default maximum number of tokens to generate.",
+    help="Default maximum number of tokens to generate. If omitted, uses model generation_config.json when available.",
 )
-@click.option("--temperature", default=1.0, type=float, help="Default sampling temperature.")
+@click.option("--temperature", default=None, type=float, help="Default sampling temperature.")
 @click.option(
-    "--top-p", default=1.0, type=float, help="Default nucleus sampling (top-p) probability."
+    "--top-p", default=None, type=float, help="Default nucleus sampling (top-p) probability."
 )
-@click.option("--top-k", default=20, type=int, help="Default top-k sampling parameter.")
-@click.option("--min-p", default=0.0, type=float, help="Default min-p sampling parameter.")
+@click.option("--top-k", default=None, type=int, help="Default top-k sampling parameter.")
+@click.option("--min-p", default=None, type=float, help="Default min-p sampling parameter.")
 @click.option(
     "--repetition-penalty",
-    default=1.0,
+    default=None,
     type=float,
     help="Default repetition penalty for token generation.",
 )
 @click.option(
     "--presence-penalty",
-    default=0.0,
+    default=None,
     type=float,
     help="Default presence penalty for token generation.",
 )
 @click.option(
     "--xtc-probability",
-    default=0.0,
+    default=None,
     type=float,
     help="Default XTC probability sampling parameter.",
 )
 @click.option(
     "--xtc-threshold",
-    default=0.0,
+    default=None,
     type=float,
     help="Default XTC threshold sampling parameter.",
 )
-@click.option("--seed", default=0, type=int, help="Default random seed for generation.")
+@click.option("--seed", default=None, type=int, help="Default random seed for generation.")
 @click.option(
     "--repetition-context-size",
-    default=20,
+    default=None,
     type=int,
     help="Default repetition context size parameter.",
 )

--- a/app/config.py
+++ b/app/config.py
@@ -72,17 +72,17 @@ class MLXServerConfig:
     batch_prefill_step_size: int = 2048
 
     # Default sampling parameters (override DEFAULT_* env when set via CLI)
-    default_max_tokens: int = 100000
-    default_temperature: float = 1.0
-    default_top_p: float = 1.0
-    default_top_k: int = 20
-    default_min_p: float = 0.0
-    default_repetition_penalty: float = 1.0
-    default_presence_penalty: float = 0.0
-    default_xtc_probability: float = 0.0
-    default_xtc_threshold: float = 0.0
-    default_seed: int = 0
-    default_repetition_context_size: int = 20
+    default_max_tokens: int | None = None
+    default_temperature: float | None = None
+    default_top_p: float | None = None
+    default_top_k: int | None = None
+    default_min_p: float | None = None
+    default_repetition_penalty: float | None = None
+    default_presence_penalty: float | None = None
+    default_xtc_probability: float | None = None
+    default_xtc_threshold: float | None = None
+    default_seed: int | None = None
+    default_repetition_context_size: int | None = None
 
     # Used to capture raw CLI input before processing
     lora_paths_str: str | None = None

--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -578,8 +578,12 @@ class MLXLMHandler:
                 request_data["checkpoint_callback"] = ctx.checkpoint_callback
 
             if self.debug:
-                log_debug_request(request_data)
-                log_debug_model_dispatch("mlx_lm.generate_text_stream.submit_stream", request_data)
+                debug_request_data = self._with_effective_sampling_params(request_data)
+                log_debug_request(debug_request_data)
+                log_debug_model_dispatch(
+                    "mlx_lm.generate_text_stream.submit_stream",
+                    debug_request_data,
+                )
                 request_data["verbose"] = True
 
             use_batch = self._is_request_batchable(request) and ctx.checkpoint_position is None
@@ -965,7 +969,10 @@ class MLXLMHandler:
                 request_data["checkpoint_callback"] = ctx.checkpoint_callback
 
             if self.debug:
-                log_debug_model_dispatch("mlx_lm.generate_text_response.submit", request_data)
+                log_debug_model_dispatch(
+                    "mlx_lm.generate_text_response.submit",
+                    self._with_effective_sampling_params(request_data),
+                )
 
             response = await self._run_nonstream_generation(request, ctx, request_data)
 
@@ -1222,6 +1229,32 @@ class MLXLMHandler:
             segments=ctx.batched_segments,
             segment_types=ctx.batched_segment_types,
         )
+
+    def _with_effective_sampling_params(self, request_data: dict[str, Any]) -> dict[str, Any]:
+        """Return a debug payload annotated with resolved sampling values.
+
+        Parameters
+        ----------
+        request_data : dict[str, Any]
+            Raw generation request data.
+
+        Returns
+        -------
+        dict[str, Any]
+            Copy of ``request_data`` with ``effective_sampling_params`` and
+            resolved top-level sampling fields for readable debug logs.
+        """
+        effective_sampling = self.model.resolve_sampling_params(request_data)
+        debug_payload = dict(request_data)
+        debug_payload.update(
+            {
+                key: value
+                for key, value in effective_sampling.items()
+                if key != "eos_token_ids" and key in debug_payload
+            }
+        )
+        debug_payload["effective_sampling_params"] = effective_sampling
+        return debug_payload
 
     def _persist_cache_if_owned(
         self,

--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -1206,7 +1206,7 @@ class MLXLMHandler:
         if max_tokens is None:
             max_tokens = params.get("max_completion_tokens")
         if max_tokens is None:
-            max_tokens = 1 << 20  # matches the "effectively unlimited" default used by MLX_LM
+            max_tokens = self.model.resolve_max_tokens(params)
 
         # Hand the full prompt to the scheduler; it does its own LRU lookup
         # and cache construction on its worker thread. For non-trimmable
@@ -1394,6 +1394,8 @@ class MLXLMHandler:
                 "seed": request.seed,
                 "repetition_penalty": request.repetition_penalty,
                 "repetition_context_size": request.repetition_context_size,
+                "presence_penalty": request.presence_penalty,
+                "frequency_penalty": request.frequency_penalty,
                 "xtc_probability": request.xtc_probability,
                 "xtc_threshold": request.xtc_threshold,
                 "logit_bias": request.logit_bias,

--- a/app/models/mlx_lm.py
+++ b/app/models/mlx_lm.py
@@ -328,6 +328,43 @@ class MLX_LM:
             max_tokens = self._sampling_default("max_completion_tokens", DEFAULT_MAX_TOKENS)
         return int(max_tokens)
 
+    def resolve_sampling_params(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Resolve the effective sampling parameters used for generation.
+
+        Parameters
+        ----------
+        params : dict[str, Any]
+            Request model parameters.
+
+        Returns
+        -------
+        dict[str, Any]
+            Sampling parameters after applying request, server, model
+            ``generation_config.json``, and built-in fallback precedence.
+        """
+
+        def _get(key: str, default: Any) -> Any:
+            value = params.get(key)
+            return self._sampling_default(key, default) if value is None else value
+
+        return {
+            "temperature": _get("temperature", DEFAULT_TEMPERATURE),
+            "top_p": _get("top_p", DEFAULT_TOP_P),
+            "top_k": _get("top_k", DEFAULT_TOP_K),
+            "min_p": _get("min_p", DEFAULT_MIN_P),
+            "max_tokens": self.resolve_max_tokens(params),
+            "seed": _get("seed", DEFAULT_SEED),
+            "repetition_penalty": _get("repetition_penalty", DEFAULT_REPETITION_PENALTY),
+            "repetition_context_size": _get(
+                "repetition_context_size", DEFAULT_REPETITION_CONTEXT_SIZE
+            ),
+            "presence_penalty": _get("presence_penalty", DEFAULT_PRESENCE_PENALTY),
+            "frequency_penalty": _get("frequency_penalty", DEFAULT_FREQUENCY_PENALTY),
+            "xtc_probability": _get("xtc_probability", DEFAULT_XTC_PROBABILITY),
+            "xtc_threshold": _get("xtc_threshold", DEFAULT_XTC_THRESHOLD),
+            "eos_token_ids": sorted(_as_int_set(getattr(self.tokenizer, "eos_token_ids", None))),
+        }
+
     def build_sampler(self, params: dict[str, Any]):
         """Build a sampler callable from a request's model parameters.
 

--- a/app/models/mlx_lm.py
+++ b/app/models/mlx_lm.py
@@ -1,6 +1,10 @@
-from collections.abc import Generator
+from __future__ import annotations
+
+from collections.abc import Generator, Iterable
 from dataclasses import dataclass
+import json
 import os
+from pathlib import Path
 from typing import Any
 
 from loguru import logger
@@ -8,7 +12,7 @@ import mlx.core as mx
 from mlx_lm.generate import GenerationResponse, stream_generate
 from mlx_lm.models.cache import can_trim_prompt_cache, make_prompt_cache
 from mlx_lm.sample_utils import make_logits_processors, make_sampler
-from mlx_lm.utils import load
+from mlx_lm.utils import _download, load
 from outlines.processors import JSONLogitsProcessor
 
 from ..utils.debug_logging import log_debug_chat_template
@@ -22,7 +26,72 @@ DEFAULT_XTC_PROBABILITY = float(os.getenv("DEFAULT_XTC_PROBABILITY", "0.0"))
 DEFAULT_XTC_THRESHOLD = float(os.getenv("DEFAULT_XTC_THRESHOLD", "0.0"))
 DEFAULT_SEED = int(os.getenv("DEFAULT_SEED", "0"))
 DEFAULT_MAX_TOKENS = int(os.getenv("DEFAULT_MAX_TOKENS", "1000000"))
+DEFAULT_REPETITION_PENALTY = float(os.getenv("DEFAULT_REPETITION_PENALTY", "0.0"))
 DEFAULT_REPETITION_CONTEXT_SIZE = int(os.getenv("DEFAULT_REPETITION_CONTEXT_SIZE", "20"))
+DEFAULT_PRESENCE_PENALTY = float(os.getenv("DEFAULT_PRESENCE_PENALTY", "0.0"))
+DEFAULT_FREQUENCY_PENALTY = float(os.getenv("DEFAULT_FREQUENCY_PENALTY", "0.0"))
+
+
+def _as_int_set(values: Any) -> set[int]:
+    """Coerce a tokenizer EOS field into a clean set of token IDs.
+
+    Parameters
+    ----------
+    values : Any
+        A token ID, sequence of token IDs, or ``None``.
+
+    Returns
+    -------
+    set[int]
+        Integer token IDs with ``None`` values removed.
+    """
+    if values is None:
+        return set()
+    if isinstance(values, int):
+        return {values}
+    if isinstance(values, Iterable) and not isinstance(values, str):
+        ids: set[int] = set()
+        for value in values:
+            if value is not None:
+                ids.add(int(value))
+        return ids
+    return {int(values)}
+
+
+def _load_generation_config(model_path: str) -> dict[str, Any]:
+    """Load model-authored generation defaults from ``generation_config.json``.
+
+    Parameters
+    ----------
+    model_path : str
+        Local model directory or Hugging Face repository name.
+
+    Returns
+    -------
+    dict[str, Any]
+        Parsed generation configuration, or an empty dictionary when the file
+        is absent or unreadable.
+    """
+    try:
+        resolved_model_path = Path(_download(model_path))
+    except (FileNotFoundError, ValueError, OSError) as exc:
+        logger.debug(f"Could not resolve model path for generation_config.json: {exc!s}")
+        resolved_model_path = Path(model_path)
+
+    generation_config_path = resolved_model_path / "generation_config.json"
+    if not generation_config_path.exists():
+        return {}
+
+    try:
+        with generation_config_path.open(encoding="utf-8") as file:
+            config = json.load(file)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(f"Failed to read {generation_config_path}: {exc!s}")
+        return {}
+
+    if not isinstance(config, dict):
+        return {}
+    return config
 
 
 @dataclass
@@ -73,8 +142,12 @@ class MLX_LM:
         debug: bool = False,
     ):
         try:
-            self.model, self.tokenizer = load(
-                model_path, lazy=False, tokenizer_config={"trust_remote_code": trust_remote_code}
+            self.generation_config = _load_generation_config(model_path)
+            self.model, self.tokenizer, model_config = load(
+                model_path,
+                lazy=False,
+                tokenizer_config={"trust_remote_code": trust_remote_code},
+                return_config=True,
             )
             self.context_length = context_length
             self.draft_model = None
@@ -84,6 +157,7 @@ class MLX_LM:
                 self._load_draft_model(draft_model_path, trust_remote_code)
             self.pad_token_id = self.tokenizer.pad_token_id
             self.bos_token = self.tokenizer.bos_token
+            self._normalize_eos_token_ids(model_config)
             self.model_type = self.model.model_type
             self.debug = debug
             self.outlines_tokenizer = OutlinesTransformerTokenizer(self.tokenizer)
@@ -109,6 +183,26 @@ class MLX_LM:
                     )
         except Exception as e:
             raise ValueError(f"Error loading model: {e!s}")
+
+    def _normalize_eos_token_ids(self, model_config: dict[str, Any]) -> None:
+        """Populate tokenizer EOS IDs strictly from model metadata.
+
+        Parameters
+        ----------
+        model_config : dict[str, Any]
+            The model configuration returned by ``mlx_lm.utils.load``. mlx-lm
+            already folds ``generation_config.json``'s ``eos_token_id`` into
+            this mapping, so this preserves the model author's stop-token list
+            without guessing extra chat terminators.
+        """
+        eos_ids = _as_int_set(getattr(self.tokenizer, "eos_token_ids", None))
+        eos_ids.update(_as_int_set(getattr(self.tokenizer, "eos_token_id", None)))
+        eos_ids.update(_as_int_set(model_config.get("eos_token_id")))
+        eos_ids.update(_as_int_set(self.generation_config.get("eos_token_id")))
+
+        if eos_ids:
+            self.tokenizer.eos_token_ids = eos_ids
+            logger.debug(f"Using EOS token IDs: {sorted(eos_ids)}")
 
     def _load_draft_model(self, draft_model_path: str, trust_remote_code: bool) -> None:
         try:
@@ -193,6 +287,47 @@ class MLX_LM:
         """Whether a draft model is configured (speculative decoding is active)."""
         return self.draft_model is not None
 
+    def _sampling_default(self, key: str, fallback: Any) -> Any:
+        """Return a generation default from model metadata or a fallback.
+
+        Parameters
+        ----------
+        key : str
+            Sampling parameter name from ``generation_config.json``.
+        fallback : Any
+            Built-in value used when the model file does not define ``key``.
+
+        Returns
+        -------
+        Any
+            The model-authored generation default when present, otherwise
+            ``fallback``.
+        """
+        value = self.generation_config.get(key)
+        return fallback if value is None else value
+
+    def resolve_max_tokens(self, params: dict[str, Any]) -> int:
+        """Resolve max generation tokens using request, model, then server defaults.
+
+        Parameters
+        ----------
+        params : dict[str, Any]
+            Request model parameters.
+
+        Returns
+        -------
+        int
+            Maximum number of tokens to generate.
+        """
+        max_tokens = params.get("max_tokens")
+        if max_tokens is None:
+            max_tokens = params.get("max_completion_tokens")
+        if max_tokens is None:
+            max_tokens = self._sampling_default("max_tokens", None)
+        if max_tokens is None:
+            max_tokens = self._sampling_default("max_completion_tokens", DEFAULT_MAX_TOKENS)
+        return int(max_tokens)
+
     def build_sampler(self, params: dict[str, Any]):
         """Build a sampler callable from a request's model parameters.
 
@@ -212,7 +347,7 @@ class MLX_LM:
 
         def _get(key: str, default: Any) -> Any:
             v = params.get(key)
-            return default if v is None else v
+            return self._sampling_default(key, default) if v is None else v
 
         sampler_kwargs: dict[str, Any] = {
             "temp": _get("temperature", DEFAULT_TEMPERATURE),
@@ -233,14 +368,24 @@ class MLX_LM:
         """Build a per-request logits-processor list from model parameters.
 
         Handles ``logit_bias``, ``repetition_penalty`` /
-        ``repetition_context_size``, and optional outlines-based JSON-schema
-        constrained decoding (``schema`` key).
+        ``repetition_context_size``, OpenAI-compatible presence/frequency
+        penalties, and optional outlines-based JSON-schema constrained
+        decoding (``schema`` key).
         """
+
+        def _penalty_value(key: str, default: float) -> float | None:
+            value = params.get(key)
+            if value is None:
+                value = self._sampling_default(key, default)
+            return None if value == 0 else value
+
         logit_bias = params.get("logit_bias")
         if logit_bias:
             logit_bias = {int(k): v for k, v in logit_bias.items()}
 
-        repetition_penalty = params.get("repetition_penalty")
+        repetition_penalty = _penalty_value("repetition_penalty", DEFAULT_REPETITION_PENALTY)
+        presence_penalty = _penalty_value("presence_penalty", DEFAULT_PRESENCE_PENALTY)
+        frequency_penalty = _penalty_value("frequency_penalty", DEFAULT_FREQUENCY_PENALTY)
         repetition_context_size = params.get("repetition_context_size")
         if repetition_context_size is None:
             repetition_context_size = DEFAULT_REPETITION_CONTEXT_SIZE
@@ -250,6 +395,8 @@ class MLX_LM:
                 logit_bias=logit_bias,
                 repetition_penalty=repetition_penalty,
                 repetition_context_size=repetition_context_size,
+                presence_penalty=presence_penalty,
+                frequency_penalty=frequency_penalty,
             )
         )
 
@@ -348,12 +495,10 @@ class MLX_LM:
 
         def _get(key, default):
             v = kwargs.get(key)
-            return default if v is None else v
+            return self._sampling_default(key, default) if v is None else v
 
         seed = _get("seed", DEFAULT_SEED)
-        max_tokens = _get("max_tokens", None)
-        if max_tokens is None:
-            max_tokens = _get("max_completion_tokens", DEFAULT_MAX_TOKENS)
+        max_tokens = self.resolve_max_tokens(kwargs)
         sampler_kwargs = {
             "temp": _get("temperature", DEFAULT_TEMPERATURE),
             "top_p": _get("top_p", DEFAULT_TOP_P),
@@ -370,7 +515,15 @@ class MLX_LM:
                 *self.tokenizer.encode("\n"),
             ]
 
-        repetition_penalty = kwargs.get("repetition_penalty")
+        repetition_penalty = _get("repetition_penalty", DEFAULT_REPETITION_PENALTY)
+        if repetition_penalty == 0:
+            repetition_penalty = None
+        presence_penalty = _get("presence_penalty", DEFAULT_PRESENCE_PENALTY)
+        if presence_penalty == 0:
+            presence_penalty = None
+        frequency_penalty = _get("frequency_penalty", DEFAULT_FREQUENCY_PENALTY)
+        if frequency_penalty == 0:
+            frequency_penalty = None
         repetition_context_size = _get("repetition_context_size", DEFAULT_REPETITION_CONTEXT_SIZE)
         logit_bias = kwargs.get("logit_bias")
 
@@ -382,6 +535,8 @@ class MLX_LM:
             logit_bias=logit_bias,
             repetition_penalty=repetition_penalty,
             repetition_context_size=repetition_context_size,
+            presence_penalty=presence_penalty,
+            frequency_penalty=frequency_penalty,
         )
 
         json_schema = kwargs.get("schema")

--- a/tests/test_cli_sampling_defaults_parity.py
+++ b/tests/test_cli_sampling_defaults_parity.py
@@ -84,6 +84,38 @@ def test_launch_accepts_repetition_penalty_and_passes_it_to_config(
     assert captured["config"].models[0].default_repetition_penalty == 1.25
 
 
+def test_launch_leaves_sampling_defaults_unset_when_flags_are_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitted CLI sampling flags should not shadow model generation_config.json."""
+
+    cli_module = _load_cli_module(monkeypatch)
+    captured: dict[str, Any] = {}
+
+    async def _fake_start_multi(config: Any) -> None:
+        captured["config"] = config
+
+    monkeypatch.setattr(cli_module, "start_multi", _fake_start_multi)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "launch",
+            "--model-path",
+            "dummy-model",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    model_config = captured["config"].models[0]
+    assert model_config.default_temperature is None
+    assert model_config.default_top_p is None
+    assert model_config.default_top_k is None
+    assert model_config.default_repetition_penalty is None
+    assert model_config.default_max_tokens is None
+
+
 def test_start_exports_repetition_penalty_before_server_setup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
fix: honor model generation_config defaults for sampling

## Summary
This branch makes the server prefer model-authored generation defaults when the user does not supply sampling parameters.

It now:
- Reads effective sampling defaults from `generation_config.json` when request, CLI, or YAML values are not provided.
- Preserves model-authored `eos_token_id` values so generation stops on the model's intended terminators.
- Logs resolved sampling parameters in debug mode instead of only the raw request payload.
- Keeps `repetition_penalty`, `presence_penalty`, and `frequency_penalty` flowing through both the batched and non-batched MLX paths.

## Notes
- CLI sampling flags now default to `None` so they do not shadow model defaults unless explicitly set.
- The change keeps request-side values highest priority, then server/config defaults, then `generation_config.json`, then built-in fallbacks.

## Verification
- `./.venv/bin/python -m pytest tests/test_cli_sampling_defaults_parity.py tests/test_chat_completions_defaults.py tests/test_batch_scheduler.py::test_default_state_machine_builds_with_eos tests/test_batch_scheduler.py::test_state_machine_includes_request_stop_words`