### PR TITLE
Fix/vlm audio inputs

### DIFF
--- a/app/core/audio_processor.py
+++ b/app/core/audio_processor.py
@@ -1,4 +1,6 @@
 import asyncio
+import base64
+import binascii
 import gc
 import os
 
@@ -11,7 +13,7 @@ class AudioProcessor(BaseProcessor):
     def __init__(self, max_workers: int = 4, cache_size: int = 1000):
         super().__init__(max_workers, cache_size)
         # Supported audio formats
-        self._supported_formats = {".mp3", ".wav"}
+        self._supported_formats = {".mp3", ".wav", ".m4a", ".ogg", ".flac", ".aac"}
 
     def _get_media_format(self, media_url: str, data: bytes = None) -> str:
         """Determine audio format from URL or data."""
@@ -85,9 +87,24 @@ class AudioProcessor(BaseProcessor):
         """Get media type name for logging."""
         return "audio"
 
-    async def process_audio_url(self, audio_url: str) -> str:
+    def _format_raw_base64_audio(self, audio_data: str, audio_format: str | None) -> str:
+        """Return a data URL for OpenAI raw base64 audio payloads."""
+        if audio_data.startswith(("data:", "http://", "https://")) or os.path.exists(audio_data):
+            return audio_data
+
+        try:
+            base64.b64decode(audio_data, validate=True)
+        except (binascii.Error, ValueError):
+            return audio_data
+
+        media_format = audio_format or "mp3"
+        return f"data:audio/{media_format};base64,{audio_data}"
+
+    async def process_audio_url(self, audio_url: str, audio_format: str | None = None) -> str:
         """Process a single audio URL and return path to cached file."""
-        return await self._process_single_media(audio_url)
+        return await self._process_single_media(
+            self._format_raw_base64_audio(audio_url, audio_format)
+        )
 
     async def process_audio_urls(self, audio_urls: list[str]) -> list[str]:
         """Process multiple audio URLs and return paths to cached files."""

--- a/app/handler/mlx_vlm.py
+++ b/app/handler/mlx_vlm.py
@@ -171,7 +171,10 @@ class MLXVLMHandler:
             log_debug_prompt(input_prompt)
 
         image_inputs, video_inputs = process_vision_info(messages)
-        vision_inputs = self.model.create_inputs(input_prompt, image_inputs, video_inputs)
+        audio_inputs = request_dict["audios"] or None
+        vision_inputs = self.model.create_inputs(
+            input_prompt, image_inputs, video_inputs, audio_inputs
+        )
 
         for key, value in vision_inputs.items():
             if isinstance(value, torch.Tensor):
@@ -683,7 +686,9 @@ class MLXVLMHandler:
 
         if isinstance(content_part, ChatCompletionContentPartInputAudio):
             audio_url = content_part.input_audio.data
-            audio_path = await self.audio_processor.process_audio_url(audio_url)
+            audio_path = await self.audio_processor.process_audio_url(
+                audio_url, audio_format=content_part.input_audio.format
+            )
             return {"content_part": {"type": "audio", "audio": audio_path}, "path": audio_path}
 
         if isinstance(content_part, ChatCompletionContentPartVideo):

--- a/app/handler/mlx_vlm.py
+++ b/app/handler/mlx_vlm.py
@@ -7,9 +7,6 @@ from typing import Any
 
 from fastapi import HTTPException
 from loguru import logger
-import mlx.core as mx
-from mlx_vlm.video_generate import process_vision_info
-import torch
 
 from ..core import AudioProcessor, ImageProcessor, InferenceWorker, VideoProcessor
 from ..message_converters import MessageConverterManager
@@ -170,15 +167,8 @@ class MLXVLMHandler:
         if self.debug:
             log_debug_prompt(input_prompt)
 
-        image_inputs, video_inputs = process_vision_info(messages)
         audio_inputs = request_dict["audios"] or None
-        vision_inputs = self.model.create_inputs(
-            input_prompt, image_inputs, video_inputs, audio_inputs
-        )
-
-        for key, value in vision_inputs.items():
-            if isinstance(value, torch.Tensor):
-                vision_inputs[key] = mx.array(value)
+        model_inputs = self.model.create_model_inputs(input_prompt, messages, audio_inputs)
 
         if self.debug:
             log_debug_request(request_dict)
@@ -192,7 +182,7 @@ class MLXVLMHandler:
             "repetition_context_size": request_dict.get("repetition_context_size"),
             "top_p": request_dict.get("top_p"),
             "schema": request_dict.get("schema"),
-            "vision_inputs": vision_inputs,
+            "model_inputs": model_inputs,
             "kv_bits": self.kv_bits,
             "kv_group_size": self.kv_group_size,
             "quantized_kv_start": self.quantized_kv_start,

--- a/app/models/mlx_vlm.py
+++ b/app/models/mlx_vlm.py
@@ -105,8 +105,9 @@ class MLX_VLM:
             self.processor.chat_template = tokenizer_template
 
     def create_input_prompt(
-        self, messages: list[dict[str, str]], chat_template_kwargs: dict[str, Any]
+        self, messages: list[dict[str, Any]], chat_template_kwargs: dict[str, Any]
     ) -> str:
+        chat_template_kwargs = dict(chat_template_kwargs)
         chat_template_kwargs.pop("_partial_mode", None)
         self._ensure_processor_chat_template()
 
@@ -114,11 +115,11 @@ class MLX_VLM:
             messages, tokenize=False, add_generation_prompt=True, **chat_template_kwargs
         )
 
-    def create_inputs(
+    def _create_processor_inputs(
         self,
         text: str,
-        images: list[str] = None,
-        videos: list[str] = None,
+        images: list[Any] = None,
+        videos: list[Any] = None,
         audios: list[str] = None,
     ) -> dict[str, Any]:
         inputs = process_inputs_with_fallback(
@@ -133,6 +134,40 @@ class MLX_VLM:
         if "attention_mask" in inputs and "mask" not in inputs:
             inputs["mask"] = inputs.pop("attention_mask")
         return inputs
+
+    def _to_mlx_inputs(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Convert tensor values produced by Transformers processors into MLX arrays."""
+        for key, value in list(inputs.items()):
+            if isinstance(value, torch.Tensor):
+                inputs[key] = mx.array(value)
+        return inputs
+
+    def create_model_inputs(
+        self,
+        text: str,
+        messages: list[dict[str, Any]],
+        audios: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create MLX-ready multimodal inputs from formatted chat messages."""
+        image_inputs, video_inputs = process_vision_info(messages)
+        inputs = self._create_processor_inputs(
+            text,
+            images=image_inputs,
+            videos=video_inputs,
+            audios=audios or None,
+        )
+        return self._to_mlx_inputs(inputs)
+
+    def create_inputs(
+        self,
+        text: str,
+        images: list[Any] = None,
+        videos: list[Any] = None,
+        audios: list[str] = None,
+    ) -> dict[str, Any]:
+        """Create processor inputs from already extracted media values."""
+        inputs = self._create_processor_inputs(text, images, videos, audios)
+        return self._to_mlx_inputs(inputs)
 
     def __call__(
         self, prompt: str, stream: bool = False, **kwargs
@@ -171,7 +206,7 @@ class MLX_VLM:
                 )
             )
 
-        model_params = dict(kwargs.get("vision_inputs") or {})
+        model_params = dict(kwargs.get("model_inputs") or kwargs.get("vision_inputs") or {})
         max_tokens = _get("max_tokens", None)
         if max_tokens is None:
             max_tokens = _get("max_completion_tokens", DEFAULT_MAX_TOKENS)

--- a/app/models/mlx_vlm.py
+++ b/app/models/mlx_vlm.py
@@ -81,7 +81,11 @@ class MLX_VLM:
                 if not os.path.exists(chat_template_file):
                     raise ValueError(f"Chat template file {chat_template_file} does not exist")
                 with open(chat_template_file) as f:
-                    self.processor.chat_template = f.read()
+                    template_content = f.read()
+                    self.processor.chat_template = template_content
+                    if hasattr(self.processor, "tokenizer"):
+                        self.processor.tokenizer.chat_template = template_content
+            self._ensure_processor_chat_template()
         except Exception as e:
             raise ValueError(f"Error loading model: {e!s}")
 
@@ -91,10 +95,20 @@ class MLX_VLM:
     def get_model_type(self):
         return self.config.model_type
 
+    def _ensure_processor_chat_template(self) -> None:
+        """Copy tokenizer chat template onto processors that do not expose one."""
+        if getattr(self.processor, "chat_template", None) is not None:
+            return
+        tokenizer = getattr(self.processor, "tokenizer", None)
+        tokenizer_template = getattr(tokenizer, "chat_template", None)
+        if tokenizer_template is not None:
+            self.processor.chat_template = tokenizer_template
+
     def create_input_prompt(
         self, messages: list[dict[str, str]], chat_template_kwargs: dict[str, Any]
     ) -> str:
         chat_template_kwargs.pop("_partial_mode", None)
+        self._ensure_processor_chat_template()
 
         return self.processor.apply_chat_template(
             messages, tokenize=False, add_generation_prompt=True, **chat_template_kwargs

--- a/app/models/mlx_vlm.py
+++ b/app/models/mlx_vlm.py
@@ -5,13 +5,12 @@ from typing import Any
 
 import mlx.core as mx
 from mlx_vlm import load, stream_generate
-from mlx_vlm.models.cache import make_prompt_cache
+from mlx_vlm.utils import process_inputs_with_fallback
 from mlx_vlm.video_generate import process_vision_info
 from outlines.processors import JSONLogitsProcessor
 import torch
 
 from ..utils.outlines_transformer_tokenizer import OutlinesTransformerTokenizer
-from ..utils.prompt_cache import LRUPromptCache
 
 # Default model parameters
 DEFAULT_MAX_TOKENS = int(os.getenv("DEFAULT_MAX_TOKENS", "100000"))
@@ -92,9 +91,6 @@ class MLX_VLM:
     def get_model_type(self):
         return self.config.model_type
 
-    def create_prompt_cache(self) -> list[Any]:
-        return make_prompt_cache(self.model.language_model, max_kv_size=self.context_length)
-
     def create_input_prompt(
         self, messages: list[dict[str, str]], chat_template_kwargs: dict[str, Any]
     ) -> str:
@@ -105,21 +101,33 @@ class MLX_VLM:
         )
 
     def create_inputs(
-        self, text: str, images: list[str] = None, videos: list[str] = None
+        self,
+        text: str,
+        images: list[str] = None,
+        videos: list[str] = None,
+        audios: list[str] = None,
     ) -> dict[str, Any]:
-        return self.processor(
-            text=[text], images=images, videos=videos, padding=True, return_tensors="pt"
+        inputs = process_inputs_with_fallback(
+            self.processor,
+            prompts=[text],
+            images=images,
+            audio=audios,
+            videos=videos,
+            padding=True,
+            return_tensors="pt",
         )
+        if "attention_mask" in inputs and "mask" not in inputs:
+            inputs["mask"] = inputs.pop("attention_mask")
+        return inputs
 
     def __call__(
-        self, prompt: str, prompt_cache: list[Any] = None, stream: bool = False, **kwargs
+        self, prompt: str, stream: bool = False, **kwargs
     ) -> CompletionResponse | Generator[str, None, None]:
         """
         Generate text response from images and messages.
 
         Args:
             prompt (str): The input prompt text.
-            prompt_cache (List[Any], optional): Prompt cache for faster inference.
             stream (bool, optional): Whether to stream the response. Defaults to False.
             **kwargs: Additional model parameters (temperature, max_tokens, etc.)
                 - schema (dict, optional): JSON schema for structured output generation.
@@ -149,7 +157,7 @@ class MLX_VLM:
                 )
             )
 
-        model_params = kwargs.get("vision_inputs")
+        model_params = dict(kwargs.get("vision_inputs") or {})
         max_tokens = _get("max_tokens", None)
         if max_tokens is None:
             max_tokens = _get("max_completion_tokens", DEFAULT_MAX_TOKENS)
@@ -176,7 +184,6 @@ class MLX_VLM:
             self.model,
             self.processor,
             prompt=prompt,
-            prompt_cache=prompt_cache,
             logits_processors=logits_processors,
             **model_params,
         )
@@ -241,8 +248,6 @@ if __name__ == "__main__":
             ],
         }
     ]
-    prompt_cache = LRUPromptCache()
-
     input_prompt = model.create_input_prompt(messages, chat_template_kwargs)
 
     image_inputs, video_inputs = process_vision_info(messages)

--- a/tests/test_multimodal_audio_inputs.py
+++ b/tests/test_multimodal_audio_inputs.py
@@ -37,7 +37,24 @@ def _load_mlx_vlm_model_module(monkeypatch: pytest.MonkeyPatch) -> Any:
     fake_utils_module.process_inputs_with_fallback = fake_process_inputs_with_fallback
 
     fake_video_module = types.ModuleType("mlx_vlm.video_generate")
-    fake_video_module.process_vision_info = lambda messages: (None, None)
+
+    def fake_process_vision_info(messages: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+        return (
+            [
+                item["image"]
+                for message in messages
+                for item in message["content"]
+                if "image" in item
+            ],
+            [
+                item["video"]
+                for message in messages
+                for item in message["content"]
+                if "video" in item
+            ],
+        )
+
+    fake_video_module.process_vision_info = fake_process_vision_info
 
     fake_outlines_module = types.ModuleType("outlines.processors")
     fake_outlines_module.JSONLogitsProcessor = object
@@ -113,6 +130,33 @@ def test_vlm_create_inputs_forwards_audio_and_normalizes_mask(
     assert inputs["videos_seen"] == ["video.mp4"]
     assert inputs["mask"] == [1, 1, 1]
     assert "attention_mask" not in inputs
+
+
+def test_vlm_create_model_inputs_owns_media_extraction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The VLM wrapper should own mlx-vlm media extraction from formatted messages."""
+    module = _load_mlx_vlm_model_module(monkeypatch)
+    model = object.__new__(module.MLX_VLM)
+    model.processor = object()
+
+    inputs = model.create_model_inputs(
+        "prompt",
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": "image.png"},
+                    {"type": "video", "video": "video.mp4"},
+                    {"type": "text", "text": "describe this"},
+                ],
+            }
+        ],
+        audios=["audio.wav"],
+    )
+
+    assert inputs["audio_seen"] == ["audio.wav"]
+    assert inputs["videos_seen"] == ["video.mp4"]
 
 
 def test_vlm_create_input_prompt_uses_tokenizer_chat_template(

--- a/tests/test_multimodal_audio_inputs.py
+++ b/tests/test_multimodal_audio_inputs.py
@@ -113,3 +113,29 @@ def test_vlm_create_inputs_forwards_audio_and_normalizes_mask(
     assert inputs["videos_seen"] == ["video.mp4"]
     assert inputs["mask"] == [1, 1, 1]
     assert "attention_mask" not in inputs
+
+
+def test_vlm_create_input_prompt_uses_tokenizer_chat_template(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Processors without chat_template should fall back to tokenizer.chat_template."""
+    module = _load_mlx_vlm_model_module(monkeypatch)
+
+    class FakeProcessor:
+        def __init__(self) -> None:
+            self.tokenizer = types.SimpleNamespace(chat_template="tokenizer-template")
+
+        def apply_chat_template(self, messages: list[dict[str, Any]], **kwargs: Any) -> str:
+            if getattr(self, "chat_template", None) is None:
+                raise ValueError("processor missing chat template")
+            return f"{self.chat_template}:{messages[0]['content']}"
+
+    model = object.__new__(module.MLX_VLM)
+    model.processor = FakeProcessor()
+
+    prompt = model.create_input_prompt(
+        [{"role": "user", "content": "hello"}],
+        {},
+    )
+
+    assert prompt == "tokenizer-template:hello"

--- a/tests/test_multimodal_audio_inputs.py
+++ b/tests/test_multimodal_audio_inputs.py
@@ -1,0 +1,115 @@
+"""Tests for multimodal audio request preparation."""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import sys
+import types
+from typing import Any
+
+import pytest
+
+
+def _load_mlx_vlm_model_module(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Import the VLM model wrapper with lightweight MLX and mlx-vlm stubs."""
+    fake_mx_module = types.ModuleType("mlx.core")
+    fake_mx_module.array = lambda value: value
+    fake_mx_module.random = types.SimpleNamespace(seed=lambda seed: None)
+
+    fake_mlx_module = types.ModuleType("mlx")
+    fake_mlx_module.core = fake_mx_module
+
+    fake_mlx_vlm_module = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm_module.load = lambda *args, **kwargs: (None, None)
+    fake_mlx_vlm_module.stream_generate = lambda *args, **kwargs: iter(())
+
+    fake_utils_module = types.ModuleType("mlx_vlm.utils")
+
+    def fake_process_inputs_with_fallback(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "input_ids": [1, 2, 3],
+            "attention_mask": [1, 1, 1],
+            "audio_seen": kwargs["audio"],
+            "videos_seen": kwargs["videos"],
+        }
+
+    fake_utils_module.process_inputs_with_fallback = fake_process_inputs_with_fallback
+
+    fake_video_module = types.ModuleType("mlx_vlm.video_generate")
+    fake_video_module.process_vision_info = lambda messages: (None, None)
+
+    fake_outlines_module = types.ModuleType("outlines.processors")
+    fake_outlines_module.JSONLogitsProcessor = object
+
+    fake_outlines_tokenizer_module = types.ModuleType("app.utils.outlines_transformer_tokenizer")
+    fake_outlines_tokenizer_module.OutlinesTransformerTokenizer = object
+
+    monkeypatch.setitem(sys.modules, "mlx", fake_mlx_module)
+    monkeypatch.setitem(sys.modules, "mlx.core", fake_mx_module)
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm_module)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.utils", fake_utils_module)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.video_generate", fake_video_module)
+    monkeypatch.setitem(sys.modules, "outlines.processors", fake_outlines_module)
+    monkeypatch.setitem(
+        sys.modules, "app.utils.outlines_transformer_tokenizer", fake_outlines_tokenizer_module
+    )
+    monkeypatch.delitem(sys.modules, "app.models.mlx_vlm", raising=False)
+
+    return importlib.import_module("app.models.mlx_vlm")
+
+
+def _load_audio_processor(monkeypatch: pytest.MonkeyPatch) -> type:
+    """Import AudioProcessor without importing MLX-dependent app.core exports."""
+    fake_mlx_lm_module = types.ModuleType("mlx_lm")
+    fake_generate_module = types.ModuleType("mlx_lm.generate")
+    fake_generate_module.BatchGenerator = object
+    fake_generate_module.SequenceStateMachine = object
+
+    monkeypatch.setitem(sys.modules, "mlx_lm", fake_mlx_lm_module)
+    monkeypatch.setitem(sys.modules, "mlx_lm.generate", fake_generate_module)
+    monkeypatch.delitem(sys.modules, "app.core", raising=False)
+    monkeypatch.delitem(sys.modules, "app.core.audio_processor", raising=False)
+
+    return importlib.import_module("app.core.audio_processor").AudioProcessor
+
+
+@pytest.mark.asyncio
+async def test_audio_processor_accepts_openai_raw_base64_audio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAI input_audio.data raw base64 should be decoded as audio, not fetched as a URL."""
+    AudioProcessor = _load_audio_processor(monkeypatch)
+    audio_data = b"RIFF" + b"\x00" * 120 + b"WAVE"
+    encoded = base64.b64encode(audio_data).decode("ascii")
+
+    processor = AudioProcessor()
+    try:
+        path = await processor.process_audio_url(encoded, audio_format="wav")
+
+        assert path.endswith(".wav")
+        with open(path, "rb") as audio_file:
+            assert audio_file.read() == audio_data
+    finally:
+        await processor.cleanup()
+
+
+def test_vlm_create_inputs_forwards_audio_and_normalizes_mask(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The VLM wrapper should pass audio files and expose attention_mask as mask."""
+    module = _load_mlx_vlm_model_module(monkeypatch)
+    model = object.__new__(module.MLX_VLM)
+    model.processor = object()
+
+    inputs = model.create_inputs(
+        "prompt",
+        images=["image.png"],
+        videos=["video.mp4"],
+        audios=["audio.wav"],
+    )
+
+    assert inputs["audio_seen"] == ["audio.wav"]
+    assert inputs["videos_seen"] == ["video.mp4"]
+    assert inputs["mask"] == [1, 1, 1]
+    assert "attention_mask" not in inputs


### PR DESCRIPTION
Title: Fix VLM tokenizer chat-template fallback and audio inputs

## Summary

- Fixes VLM prompt creation for processors, including Nemotron-3-Nano-Omni and affected Qwen3.5 models, when the chat template is exposed on `processor.tokenizer.chat_template` instead of `processor.chat_template`.
- Routes VLM request preparation through `MLX_VLM.create_model_inputs()` so image, video, and audio inputs are assembled consistently before generation.
- Adds OpenAI `input_audio` raw base64 handling by converting it into a data URL before audio caching, while preserving URL/path inputs.
- Expands supported audio formats to include `.m4a`, `.ogg`, `.flac`, and `.aac`.
- Adds regression coverage for raw base64 audio processing, audio forwarding into VLM inputs, media extraction ownership, and tokenizer chat-template fallback.

## Issue

Fixes https://github.com/cubist38/mlx-openai-server/issues/292
Fixes https://github.com/cubist38/mlx-openai-server/issues/264

## Testing

- Manual launch:

```bash
mlx-openai-server launch --model-path mlx-community/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit --model-type multimodal --reasoning-parser nemotron3_nano --tool-call-parser nemotron3_nano
```