### PR TITLE
Fix/lm thread affinity and batching policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ LM-specific memory and batching options:
 | `--draft-model-path` | unset | Smaller draft model for speculative decoding |
 | `--num-draft-tokens` | `2` | Draft tokens proposed per step |
 
+When continuous batching is enabled, LM requests stay on the batched generation path whenever the model supports batched KV-cache merging. Per-request positive `seed` values are ignored in this mode because the batch scheduler shares one RNG lane; launch with `--disable-batching` if request-level seed reproducibility is required.
+
+Prompt KV caches are reused only by the generation path that created them. Batched and non-batched requests use separate cache entries because MLX cache and stream objects are thread-affine.
+
 ## Multi-Model Config
 
 Use YAML when you want several models behind one server:
@@ -427,6 +431,7 @@ Chat completions accept OpenAI-style `response_format` JSON schema. The Response
 |-------|-----|
 | Model does not fit in memory | Use a smaller or pre-quantized model, lower `--context-length`, and see [Long Context and Metal OOM](#long-context-and-metal-oom). |
 | Metal OOM during batching | Lower `--prompt-concurrency`, `--prefill-step-size`, `--decode-concurrency`, and `--max-tokens`. |
+| `There is no Stream(gpu, N) in current thread` | Keep prompt-cache persistence on the worker thread and avoid sharing cache payloads across batch/non-batch paths; use `--disable-batching` when request seeds or single-request behavior are required. |
 | Port already in use | Pass `--port 8001` or another free port. |
 | Image model memory is too high | Use `--quantize 4` or `--quantize 8`. |
 | Model loading says parameters are missing or unexpected | Upgrade the backend package from source. |

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ LM-specific memory and batching options:
 | `--decode-concurrency` | `32` | Max concurrent batch decode sequences |
 | `--prompt-concurrency` | `8` | Max prompts prefilled together |
 | `--prefill-step-size` | `2048` | Tokens per prefill step |
+| `--disable-batching` | `false` | Disable continuous batching; required if per-request positive `seed` values must be honored |
 | `--prompt-cache-size` | `10` | Retained prompt KV cache entries |
 | `--max-bytes` | unbounded | Prompt KV cache byte budget |
 | `--prompt-cache-dir` | temp dir | Directory for disk-backed prompt KV cache payloads |
@@ -310,7 +311,7 @@ Important YAML keys:
 | `model_path`, `model_type`, `served_model_name` | Model identity and routing |
 | `context_length` | LM/multimodal context length |
 | `prompt_cache_size`, `prompt_cache_max_bytes`, `prompt_cache_dir` | Prompt KV cache limits and disk location |
-| `batch_completion_size`, `batch_prefill_size`, `batch_prefill_step_size` | Continuous batching limits |
+| `batch_completion_size`, `batch_prefill_size`, `batch_prefill_step_size`, `disable_batching` | Continuous batching controls |
 | `kv_bits`, `kv_group_size`, `quantized_kv_start` | KV cache quantization |
 | `default_max_tokens` | Default generated tokens |
 | `on_demand`, `on_demand_idle_timeout` | Load large models only when requested |

--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -9,7 +9,7 @@ import json
 import os
 import random
 import time
-from typing import Annotated, Any, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from fastapi import APIRouter, Form, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -20,8 +20,6 @@ from openai.types.responses.response_function_tool_call import ResponseFunctionT
 from openai.types.responses.response_output_message import ResponseOutputMessage, ResponseOutputText
 from openai.types.responses.response_reasoning_item import Content, ResponseReasoningItem, Summary
 
-from ..handler.mlx_lm import MLXLMHandler
-from ..handler.mlx_vlm import MLXVLMHandler
 from ..schemas.openai import (
     ChatCompletionChunk,
     ChatCompletionContentPartImage,
@@ -59,6 +57,10 @@ from ..schemas.openai import (
     UsageInfo,
     random_uuid,
 )
+
+if TYPE_CHECKING:
+    from ..handler.mlx_lm import MLXLMHandler
+    from ..handler.mlx_vlm import MLXVLMHandler
 from ..utils.debug_logging import log_debug_server_request
 from ..utils.errors import create_error_response
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -332,6 +332,15 @@ def cli():
         "Only applies to 'lm' model types. Default is 2048."
     ),
 )
+@click.option(
+    "--disable-batching",
+    is_flag=True,
+    default=False,
+    help=(
+        "Disable continuous batching for LM models. Use this when per-request "
+        "positive seeds must be honored."
+    ),
+)
 # Sampling parameters (defaults used when API request omits them)
 @click.option(
     "--max-tokens",
@@ -411,6 +420,7 @@ def launch(
     batch_completion_size,
     batch_prefill_size,
     batch_prefill_step_size,
+    disable_batching,
     max_tokens,
     temperature,
     top_p,
@@ -486,6 +496,7 @@ def launch(
         batch_completion_size=batch_completion_size,
         batch_prefill_size=batch_prefill_size,
         batch_prefill_step_size=batch_prefill_step_size,
+        disable_batching=disable_batching,
         default_max_tokens=max_tokens,
         default_temperature=temperature,
         default_top_p=top_p,

--- a/app/cli.py
+++ b/app/cli.py
@@ -19,15 +19,7 @@ from .main import start_multi
 from .parsers import REASONING_PARSER_MAP, TOOL_PARSER_MAP, UNIFIED_PARSER_MAP
 from .version import __version__
 
-try:
-    from .models.mflux import IMAGE_CONFIG_NAMES
-except ImportError as exc:
-    IMAGE_CONFIG_NAMES: tuple[str, ...] = ()
-    MFLUX_AVAILABLE = False
-    MFLUX_IMPORT_ERROR: ImportError | None = exc
-else:
-    MFLUX_AVAILABLE = True
-    MFLUX_IMPORT_ERROR = None
+IMAGE_CONFIG_NAMES: tuple[str, ...] = ()
 
 MFLUX_INSTALL_HINT = (
     "Image generation and editing require the `mflux` package. "
@@ -90,11 +82,16 @@ def ensure_image_support_available(model_types: set[str]) -> None:
     if not any(model_type in {"image-generation", "image-edit"} for model_type in model_types):
         return
 
-    if MFLUX_AVAILABLE:
+    try:
+        import mflux  # noqa: F401
+    except ImportError as exc:
+        detail = f" Optional import failed: {exc!s}"
+        raise click.UsageError(f"{MFLUX_INSTALL_HINT}{detail}") from exc
+    except RuntimeError as exc:
+        detail = f" Optional import failed: {exc!s}"
+        raise click.UsageError(f"{MFLUX_INSTALL_HINT}{detail}") from exc
+    else:
         return
-
-    detail = f" Optional import failed: {MFLUX_IMPORT_ERROR!s}" if MFLUX_IMPORT_ERROR else ""
-    raise click.UsageError(f"{MFLUX_INSTALL_HINT}{detail}")
 
 
 # Configure basic logging for CLI (will be overridden by main.py)

--- a/app/cli.py
+++ b/app/cli.py
@@ -19,7 +19,20 @@ from .main import start_multi
 from .parsers import REASONING_PARSER_MAP, TOOL_PARSER_MAP, UNIFIED_PARSER_MAP
 from .version import __version__
 
-IMAGE_CONFIG_NAMES: tuple[str, ...] = ()
+IMAGE_CONFIG_NAMES: tuple[str, ...] = (
+    "flux-schnell",
+    "flux-dev",
+    "flux-krea-dev",
+    "flux-kontext-dev",
+    "qwen-image",
+    "qwen-image-edit",
+    "fibo",
+    "z-image-turbo",
+    "flux2-klein-4b",
+    "flux2-klein-9b",
+    "flux2-klein-edit-4b",
+    "flux2-klein-edit-9b",
+)
 
 MFLUX_INSTALL_HINT = (
     "Image generation and editing require the `mflux` package. "

--- a/app/config.py
+++ b/app/config.py
@@ -70,6 +70,7 @@ class MLXServerConfig:
     batch_completion_size: int = 32
     batch_prefill_size: int = 8
     batch_prefill_step_size: int = 2048
+    disable_batching: bool = False
 
     # Default sampling parameters (override DEFAULT_* env when set via CLI)
     default_max_tokens: int | None = None
@@ -204,6 +205,7 @@ class MLXServerConfig:
             batch_completion_size=self.batch_completion_size,
             batch_prefill_size=self.batch_prefill_size,
             batch_prefill_step_size=self.batch_prefill_step_size,
+            disable_batching=self.disable_batching,
             # Sampling defaults: the subprocess path reads them off the
             # handler proxy rather than the ``DEFAULT_*`` env vars (which
             # would not be set inside the child process).
@@ -300,6 +302,7 @@ class ModelEntryConfig:
     batch_completion_size: int = 32
     batch_prefill_size: int = 8
     batch_prefill_step_size: int = 2048
+    disable_batching: bool = False
     default_max_tokens: int | None = None
     default_temperature: float | None = None
     default_top_p: float | None = None

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,11 +1,8 @@
-from .audio_processor import AudioProcessor
-from .base_processor import BaseProcessor
-from .batch_scheduler import BatchChunk, BatchScheduler
-from .handler_process import HandlerProcessProxy
-from .image_processor import ImageProcessor
-from .inference_worker import InferenceWorker
-from .model_registry import ModelRegistry
-from .video_processor import VideoProcessor
+"""Core server utilities with lazy backend imports."""
+
+from __future__ import annotations
+
+from typing import Any
 
 __all__ = [
     "AudioProcessor",
@@ -18,3 +15,44 @@ __all__ = [
     "ModelRegistry",
     "VideoProcessor",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import core helpers so one backend does not initialize all stacks."""
+    if name == "AudioProcessor":
+        from .audio_processor import AudioProcessor
+
+        return AudioProcessor
+    if name == "BaseProcessor":
+        from .base_processor import BaseProcessor
+
+        return BaseProcessor
+    if name == "BatchChunk":
+        from .batch_scheduler import BatchChunk
+
+        return BatchChunk
+    if name == "BatchScheduler":
+        from .batch_scheduler import BatchScheduler
+
+        return BatchScheduler
+    if name == "HandlerProcessProxy":
+        from .handler_process import HandlerProcessProxy
+
+        return HandlerProcessProxy
+    if name == "ImageProcessor":
+        from .image_processor import ImageProcessor
+
+        return ImageProcessor
+    if name == "InferenceWorker":
+        from .inference_worker import InferenceWorker
+
+        return InferenceWorker
+    if name == "ModelRegistry":
+        from .model_registry import ModelRegistry
+
+        return ModelRegistry
+    if name == "VideoProcessor":
+        from .video_processor import VideoProcessor
+
+        return VideoProcessor
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/app/core/batch_scheduler.py
+++ b/app/core/batch_scheduler.py
@@ -558,7 +558,8 @@ class BatchScheduler:
             elif self._prompt_cache is not None:
                 try:
                     fetched_cache, fetched_rest = self._prompt_cache.fetch_nearest_cache(
-                        request.input_ids
+                        request.input_ids,
+                        allowed_sources={"batch"},
                     )
                 except Exception as exc:  # noqa: BLE001 — fallback to fresh cache
                     logger.warning(f"prompt_cache.fetch_nearest_cache failed: {exc!s}")
@@ -683,7 +684,10 @@ class BatchScheduler:
 
         if self._prompt_cache is not None:
             try:
-                prefix_cache, prefix_rest = self._prompt_cache.fetch_nearest_cache(input_ids[:-1])
+                prefix_cache, prefix_rest = self._prompt_cache.fetch_nearest_cache(
+                    input_ids[:-1],
+                    allowed_sources={"batch"},
+                )
             except Exception as exc:  # noqa: BLE001 — exact-hit fallback is best-effort
                 logger.warning(f"Failed to back off exact prompt-cache hit: {exc!s}")
             else:
@@ -777,6 +781,7 @@ class BatchScheduler:
                     list(cache_key),
                     cache,
                     cache_type=cache_type,
+                    source="batch",
                 )
                 logger.debug(
                     f"BatchScheduler saved {cache_type} checkpoint for uid={uid}"
@@ -860,6 +865,7 @@ class BatchScheduler:
                             list(resp.all_tokens),
                             resp.prompt_cache,
                             cache_type="assistant",
+                            source="batch",
                         )
                         saved = True
                     except Exception as exc:  # noqa: BLE001 — cache save is best-effort

--- a/app/core/inference_worker.py
+++ b/app/core/inference_worker.py
@@ -66,21 +66,24 @@ class InferenceWorker:
 
     def _run(self) -> None:
         stream_context = self._create_stream_context()
-        while self._running:
-            try:
-                work = self._work_queue.get(timeout=0.1)
-            except queue.Empty:
-                continue
-            with self._lock:
-                self._active = True
-            try:
-                with stream_context():
-                    work()
-            except Exception:
-                logger.exception("Inference worker: exception escaped work closure")
-            finally:
+        try:
+            while self._running:
+                try:
+                    work = self._work_queue.get(timeout=0.1)
+                except queue.Empty:
+                    continue
                 with self._lock:
-                    self._active = False
+                    self._active = True
+                try:
+                    with stream_context():
+                        work()
+                except Exception:
+                    logger.exception("Inference worker: exception escaped work closure")
+                finally:
+                    with self._lock:
+                        self._active = False
+        finally:
+            self._stream = None
 
     def _create_stream_context(self) -> Callable[[], Any]:
         """Create a worker-thread-local MLX stream context when MLX is available.
@@ -96,11 +99,15 @@ class InferenceWorker:
             logger.debug(f"Inference worker could not initialize MLX stream: {exc!s}")
             return nullcontext
 
-        new_thread_local_stream = getattr(mx, "new_thread_local_stream", None)
-        if new_thread_local_stream is not None:
-            self._stream = new_thread_local_stream(mx.default_device())
-        else:
-            self._stream = mx.new_stream(mx.default_device())
+        try:
+            new_thread_local_stream = getattr(mx, "new_thread_local_stream", None)
+            if new_thread_local_stream is not None:
+                self._stream = new_thread_local_stream(mx.default_device())
+            else:
+                self._stream = mx.new_stream(mx.default_device())
+        except RuntimeError as exc:
+            logger.debug(f"Inference worker could not create MLX stream: {exc!s}")
+            return nullcontext
         return lambda: mx.stream(self._stream)
 
     def _record(self, success: bool) -> None:

--- a/app/core/inference_worker.py
+++ b/app/core/inference_worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator, Callable, Generator
+from contextlib import nullcontext
 import queue
 import threading
 from threading import Thread
@@ -44,6 +45,7 @@ class InferenceWorker:
         self._active = False
         self._completed = 0
         self._failed = 0
+        self._stream: Any = None
 
     def start(self) -> None:
         if self._running:
@@ -63,6 +65,7 @@ class InferenceWorker:
         logger.info("Inference worker thread stopped")
 
     def _run(self) -> None:
+        stream_context = self._create_stream_context()
         while self._running:
             try:
                 work = self._work_queue.get(timeout=0.1)
@@ -71,12 +74,34 @@ class InferenceWorker:
             with self._lock:
                 self._active = True
             try:
-                work()
+                with stream_context():
+                    work()
             except Exception:
                 logger.exception("Inference worker: exception escaped work closure")
             finally:
                 with self._lock:
                     self._active = False
+
+    def _create_stream_context(self) -> Callable[[], Any]:
+        """Create a worker-thread-local MLX stream context when MLX is available.
+
+        MLX streams are thread-affine. The inference worker owns all
+        single-request model execution, so its stream must be allocated on
+        this worker thread and every submitted work item must run under that
+        stream.
+        """
+        try:
+            import mlx.core as mx  # noqa: PLC0415
+        except (ImportError, RuntimeError) as exc:
+            logger.debug(f"Inference worker could not initialize MLX stream: {exc!s}")
+            return nullcontext
+
+        new_thread_local_stream = getattr(mx, "new_thread_local_stream", None)
+        if new_thread_local_stream is not None:
+            self._stream = new_thread_local_stream(mx.default_device())
+        else:
+            self._stream = mx.new_stream(mx.default_device())
+        return lambda: mx.stream(self._stream)
 
     def _record(self, success: bool) -> None:
         with self._lock:
@@ -120,6 +145,7 @@ class InferenceWorker:
         cancel_event = threading.Event()
 
         def _work() -> None:
+            gen: Generator[Any, None, None] | None = None
             try:
                 gen = func(*args, **kwargs)
                 for item in gen:
@@ -132,6 +158,12 @@ class InferenceWorker:
             except BaseException as e:
                 loop.call_soon_threadsafe(token_queue.put_nowait, e)
                 self._record(False)
+            finally:
+                if gen is not None:
+                    try:
+                        gen.close()
+                    except Exception as exc:  # noqa: BLE001 - close is best-effort cleanup
+                        logger.warning(f"Inference stream cleanup failed: {exc!s}")
 
         try:
             self._work_queue.put_nowait(_work)

--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -449,6 +449,11 @@ class MLXLMHandler:
 
         with self._generation_lock:
             cache, rest_input_ids = self.prompt_cache.fetch_nearest_cache(input_ids)
+            cache, rest_input_ids = self._normalize_nonbatch_cache_hit(
+                input_ids,
+                cache,
+                rest_input_ids,
+            )
             if cache is None:
                 cache = self.model.create_prompt_cache()
 
@@ -542,6 +547,70 @@ class MLXLMHandler:
             checkpoint_position=checkpoint_position,
             checkpoint_callback=checkpoint_callback,
         )
+
+    def _normalize_nonbatch_cache_hit(
+        self,
+        input_ids: list[int],
+        cache: list[Any] | None,
+        rest_input_ids: list[int],
+    ) -> tuple[list[Any] | None, list[int]]:
+        """Ensure fallback generation always receives at least one prompt token.
+
+        Parameters
+        ----------
+        input_ids : list[int]
+            Full encoded prompt tokens.
+        cache : list[Any] | None
+            Prompt cache returned by the LRU lookup.
+        rest_input_ids : list[int]
+            Prompt suffix not covered by ``cache``.
+
+        Returns
+        -------
+        tuple[list[Any] | None, list[int]]
+            A cache and prompt suffix suitable for the single-request
+            generator. Exact cache hits are backed off by one token when
+            possible; otherwise the cache hit is discarded.
+        """
+        if cache is None or rest_input_ids:
+            return cache, rest_input_ids
+        if len(input_ids) <= 1:
+            return None, input_ids
+
+        try:
+            from mlx_lm.models.cache import can_trim_prompt_cache, trim_prompt_cache
+        except ImportError as exc:
+            logger.debug(f"Could not import prompt-cache trim helpers: {exc!s}")
+        else:
+            try:
+                if can_trim_prompt_cache(cache):
+                    trim_prompt_cache(cache, 1)
+                    return cache, input_ids[-1:]
+            except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+                logger.warning(f"Failed to back off exact prompt-cache hit: {exc!s}")
+
+        try:
+            prefix_cache, prefix_rest = self.prompt_cache.fetch_nearest_cache(input_ids[:-1])
+        except (
+            AttributeError,
+            KeyError,
+            IndexError,
+            OSError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            logger.warning(f"Failed to find shorter prompt-cache hit: {exc!s}")
+        else:
+            cached_prefix_len = len(input_ids[:-1]) - len(prefix_rest)
+            if prefix_cache is not None and cached_prefix_len < len(input_ids):
+                return prefix_cache, input_ids[cached_prefix_len:]
+
+        logger.info(
+            "Discarding exact prompt-cache hit because fallback generation needs at least "
+            f"one prompt token (prompt_tokens={len(input_ids)})"
+        )
+        return None, input_ids
 
     async def generate_text_stream(  # noqa: C901
         self, request: ChatCompletionRequest

--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -138,6 +138,7 @@ class MLXLMHandler:
         batch_prefill_size: int = 8,
         batch_prefill_step_size: int = 2048,
         batch_max_kv_size: int | None = None,
+        disable_batching: bool = False,
     ):
         """
         Initialize the handler with the specified model path.
@@ -188,6 +189,9 @@ class MLXLMHandler:
         batch_max_kv_size : int | None
             Rotating-KV-cache size for the scheduler; ``None`` keeps full
             history (same default used by ``mlx_lm``).
+        disable_batching : bool
+            Disable the continuous batch scheduler and use the single-request
+            path for LM generation.
         """
         self.model_path = model_path
         from ..models.mlx_lm import MLX_LM
@@ -236,6 +240,7 @@ class MLXLMHandler:
         self._batch_prefill_size = batch_prefill_size
         self._batch_prefill_step_size = batch_prefill_step_size
         self._batch_max_kv_size = batch_max_kv_size
+        self._disable_batching = disable_batching
         self._batch_scheduler: BatchScheduler | None = None
         self._batch_scheduler_lock = asyncio.Lock()
         self._generation_lock = threading.RLock()
@@ -1203,19 +1208,18 @@ class MLXLMHandler:
         one). This predicate only returns False for features that the batched
         ``BatchGenerator`` does not support:
 
-        * A non-trivial per-request ``seed`` — the batch path shares a single
-          RNG, matching ``mlx_lm``'s own server. We mirror
-          :meth:`MLX_LM.__call__`'s seeding rule (``seed and seed >= 0``)
-          rather than ``seed is not None``, because the CLI default
-          ``--seed 0`` is backfilled into every request by the endpoint as
-          "no explicit seed"; treating that as non-batchable would pin every
-          request to the single-request path.
         * Speculative decoding via ``draft_model``.
+
+        Per-request positive seeds are ignored while batching is enabled. To
+        use request seeds, start the server with ``--disable-batching`` so all
+        LM requests use the single-request generation path.
 
         Requests that require a mid-prefill cache checkpoint are also routed
         through the single-request path — that check is applied at the call
         site where the checkpoint position is known.
         """
+        if getattr(self, "_disable_batching", False):
+            return False
         if not BATCHING_AVAILABLE:
             return False
         if self.model.has_draft_model:
@@ -1226,8 +1230,6 @@ class MLXLMHandler:
         # ``mlx_lm.server``'s own ``is_batchable`` check) can only run on
         # the single-request path.
         if not self.model.cache_is_batchable:
-            return False
-        if request.seed is not None and request.seed > 0:
             return False
         return True
 
@@ -1437,6 +1439,7 @@ class MLXLMHandler:
                 ),
                 "completion_batch_size": self._batch_completion_size,
                 "prefill_batch_size": self._batch_prefill_size,
+                "disabled": self._disable_batching,
             },
         }
 
@@ -1581,6 +1584,14 @@ class MLXLMHandler:
             # Communicate partial mode to create_input_prompt via chat_template_kwargs
             if is_partial:
                 chat_template_kwargs["_partial_mode"] = True
+
+            seed = model_params.get("seed")
+            if self._is_request_batchable(request) and seed is not None and seed > 0:
+                logger.warning(
+                    "Ignoring per-request seed because continuous batching is enabled; "
+                    "start the server with --disable-batching to use request seeds."
+                )
+                model_params["seed"] = 0
 
             return chat_messages, model_params
 

--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -448,7 +448,10 @@ class MLXLMHandler:
             )
 
         with self._generation_lock:
-            cache, rest_input_ids = self.prompt_cache.fetch_nearest_cache(input_ids)
+            cache, rest_input_ids = self.prompt_cache.fetch_nearest_cache(
+                input_ids,
+                allowed_sources={"nonbatch"},
+            )
             cache, rest_input_ids = self._normalize_nonbatch_cache_hit(
                 input_ids,
                 cache,
@@ -590,7 +593,10 @@ class MLXLMHandler:
                 logger.warning(f"Failed to back off exact prompt-cache hit: {exc!s}")
 
         try:
-            prefix_cache, prefix_rest = self.prompt_cache.fetch_nearest_cache(input_ids[:-1])
+            prefix_cache, prefix_rest = self.prompt_cache.fetch_nearest_cache(
+                input_ids[:-1],
+                allowed_sources={"nonbatch"},
+            )
         except (
             AttributeError,
             KeyError,

--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -307,6 +307,44 @@ class MLXLMHandler:
         with self._generation_lock:
             yield from self.model(*args, **kwargs)
 
+    def _generate_with_lock_and_cache_persist(
+        self,
+        cache_key: list[int],
+        cache: list[Any] | None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Run non-stream generation and persist its prompt cache on the worker thread."""
+        with self._generation_lock:
+            response = self.model(*args, **kwargs)
+            if cache is not None:
+                try:
+                    self.prompt_cache.insert_cache(cache_key + response.tokens, cache)
+                except Exception as cache_error:  # noqa: BLE001 - cache persistence is best-effort
+                    logger.warning(f"Failed to persist prompt cache: {cache_error}")
+            return response
+
+    def _stream_with_lock_and_cache_persist(
+        self,
+        cache_key: list[int],
+        cache: list[Any] | None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Stream non-batched generation and persist its cache on the worker thread."""
+        with self._generation_lock:
+            try:
+                for chunk in self.model(*args, **kwargs):
+                    if chunk is not None:
+                        cache_key.append(chunk.token)
+                    yield chunk
+            finally:
+                if cache is not None:
+                    try:
+                        self.prompt_cache.insert_cache(cache_key, cache)
+                    except Exception as cache_error:  # noqa: BLE001 - cache persistence is best-effort
+                        logger.warning(f"Failed to persist prompt cache: {cache_error}")
+
     def _insert_prompt_cache(
         self,
         cache_key: list[int],
@@ -636,14 +674,8 @@ class MLXLMHandler:
         Yields:
             str or dict: Response chunks (str) followed by usage info (dict) at the end.
         """
-        cache: list[Any] | None = None
-        cache_key: list[int] | None = None
-        cache_inserted = False
-
         try:
             ctx = await self._build_inference_context(request)
-            cache = ctx.cache
-            cache_key = ctx.cache_key
             total_input_tokens = ctx.total_input_tokens
             total_cached_tokens = ctx.total_cached_tokens
             model_params = ctx.model_params
@@ -672,9 +704,11 @@ class MLXLMHandler:
                 response_generator = self._submit_batched_stream(scheduler, ctx)
             else:
                 response_generator = self.inference_worker.submit_stream(
-                    self._stream_with_lock,
+                    self._stream_with_lock_and_cache_persist,
+                    list(ctx.cache_key),
+                    ctx.cache,
                     input_ids=ctx.rest_input_ids,
-                    prompt_cache=cache,
+                    prompt_cache=ctx.cache,
                     stream=True,
                     **request_data,
                 )
@@ -695,7 +729,6 @@ class MLXLMHandler:
                     final_chunk = chunk
                     text = chunk.text
                     raw_text += text
-                    cache_key.append(chunk.token)
 
                     if unified_parser:
                         if self.debug:
@@ -757,7 +790,6 @@ class MLXLMHandler:
                     final_chunk = chunk
                     text = chunk.text
                     raw_text += text
-                    cache_key.append(chunk.token)
                     if is_first_chunk:
                         if reasoning_parser and hasattr(
                             reasoning_parser, "needs_redacted_reasoning_prefix"
@@ -964,13 +996,6 @@ class MLXLMHandler:
                         yield text
 
             total_tokens = total_input_tokens + final_chunk.generation_tokens
-            if cache is not None:
-                # Non-batch path owns the cache on the event-loop thread.
-                # The batched path stores its final cache from the scheduler
-                # thread instead (see BatchScheduler._handle_generation_response).
-                self._insert_prompt_cache(cache_key, cache)
-            cache_inserted = True
-
             if self.debug:
                 self.prompt_cache.log_cache_stats()
                 log_debug_raw_text_response(raw_text)
@@ -1011,16 +1036,6 @@ class MLXLMHandler:
                 HTTPStatus.INTERNAL_SERVER_ERROR,
             )
             raise HTTPException(status_code=500, detail=content)
-        finally:
-            if cache is not None and cache_key is not None and not cache_inserted:
-                try:
-                    self._insert_prompt_cache(cache_key, cache)
-                    if self.debug:
-                        self.prompt_cache.log_cache_stats()
-                except Exception as cache_error:
-                    logger.warning(
-                        f"Failed to persist prompt cache during stream finalization: {cache_error}"
-                    )
 
     async def generate_text_response(self, request: ChatCompletionRequest) -> dict[str, Any]:
         """
@@ -1057,9 +1072,6 @@ class MLXLMHandler:
             response = await self._run_nonstream_generation(request, ctx, request_data)
 
             response_text = response.text
-            cache_key = ctx.cache_key
-            cache_key += response.tokens
-            self._persist_cache_if_owned(cache_key, ctx.cache)
 
             parsed_response = {"reasoning_content": None, "tool_calls": None, "content": None}
 
@@ -1333,21 +1345,6 @@ class MLXLMHandler:
         debug_payload["effective_sampling_params"] = effective_sampling
         return debug_payload
 
-    def _persist_cache_if_owned(
-        self,
-        cache_key: list[int],
-        cache: list[Any] | None,
-    ) -> None:
-        """Store ``cache`` into the LRU only when the event-loop thread owns it.
-
-        The batched path delegates cache persistence to the scheduler thread
-        (see :meth:`BatchScheduler._handle_generation_response`), so this
-        helper is a no-op when ``cache`` is ``None``.
-        """
-        if cache is None:
-            return
-        self._insert_prompt_cache(cache_key, cache)
-
     async def _run_nonstream_generation(
         self,
         request: ChatCompletionRequest,
@@ -1363,7 +1360,9 @@ class MLXLMHandler:
             scheduler = await self._get_or_start_scheduler()
             return await self._collect_batched_response(scheduler, ctx)
         return await self.inference_worker.submit(
-            self._generate_with_lock,
+            self._generate_with_lock_and_cache_persist,
+            list(ctx.cache_key),
+            ctx.cache,
             input_ids=ctx.rest_input_ids,
             prompt_cache=ctx.cache,
             stream=False,

--- a/app/main.py
+++ b/app/main.py
@@ -115,11 +115,14 @@ def print_startup_banner(config_args: MLXServerConfig) -> None:
         )
         if getattr(config_args, "prompt_cache_dir", None):
             logger.info(f"💾 Prompt Cache Dir: {config_args.prompt_cache_dir}")
-        logger.info(
-            f"🧵 Batch Scheduler: decode={config_args.batch_completion_size}, "
-            f"prefill={config_args.batch_prefill_size}, "
-            f"prefill_step={config_args.batch_prefill_step_size}"
-        )
+        if config_args.disable_batching:
+            logger.info("🧵 Batch Scheduler: Disabled")
+        else:
+            logger.info(
+                f"🧵 Batch Scheduler: decode={config_args.batch_completion_size}, "
+                f"prefill={config_args.batch_prefill_size}, "
+                f"prefill_step={config_args.batch_prefill_step_size}"
+            )
     logger.info(f"📝 Log Level: {config_args.log_level}")
     if config_args.no_log_file:
         logger.info("📝 File Logging: Disabled")
@@ -165,11 +168,22 @@ def _model_entry_extras(m: ModelEntryConfig) -> list[tuple[str, object]]:
         )
     if m.model_type == "lm":
         batch_settings: list[str] = []
-        if m.batch_completion_size != _MODEL_ENTRY_DEFAULTS["batch_completion_size"]:
+        if m.disable_batching:
+            batch_settings.append("disabled")
+        if (
+            not m.disable_batching
+            and m.batch_completion_size != _MODEL_ENTRY_DEFAULTS["batch_completion_size"]
+        ):
             batch_settings.append(f"decode={m.batch_completion_size}")
-        if m.batch_prefill_size != _MODEL_ENTRY_DEFAULTS["batch_prefill_size"]:
+        if (
+            not m.disable_batching
+            and m.batch_prefill_size != _MODEL_ENTRY_DEFAULTS["batch_prefill_size"]
+        ):
             batch_settings.append(f"prefill={m.batch_prefill_size}")
-        if m.batch_prefill_step_size != _MODEL_ENTRY_DEFAULTS["batch_prefill_step_size"]:
+        if (
+            not m.disable_batching
+            and m.batch_prefill_step_size != _MODEL_ENTRY_DEFAULTS["batch_prefill_step_size"]
+        ):
             batch_settings.append(f"prefill_step={m.batch_prefill_step_size}")
         if batch_settings:
             extras.append(("batch_scheduler", ", ".join(batch_settings)))

--- a/app/server.py
+++ b/app/server.py
@@ -107,7 +107,7 @@ def configure_logging(
 
     # Add console handler
     logger.add(
-        lambda msg: print(msg),
+        print,
         level=log_level,
         format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
         "<level>{level: <8}</level> | "
@@ -328,6 +328,7 @@ def create_handler_from_config(model_cfg: ModelEntryConfig) -> Any:
             batch_completion_size=model_cfg.batch_completion_size,
             batch_prefill_size=model_cfg.batch_prefill_size,
             batch_prefill_step_size=model_cfg.batch_prefill_step_size,
+            disable_batching=model_cfg.disable_batching,
         ),
         model_cfg,
     )

--- a/app/server.py
+++ b/app/server.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 import gc
 import importlib.util
+import sys
 import time
 from typing import Any
 
@@ -68,8 +69,10 @@ _SAMPLING_DEFAULT_FIELDS: tuple[str, ...] = (
 
 
 def _clear_mlx_cache() -> None:
-    """Clear MLX cache only after a handler path actually needs MLX."""
-    import mlx.core as mx
+    """Clear MLX cache without importing MLX into processes that do not use it."""
+    mx = sys.modules.get("mlx.core")
+    if mx is None:
+        return
 
     mx.clear_cache()
 

--- a/app/server.py
+++ b/app/server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 import gc
+import importlib.util
 import time
 from typing import Any
 
@@ -26,18 +27,12 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from loguru import logger
-import mlx.core as mx
 import uvicorn
 
 from .api.endpoints import router
 from .config import MLXServerConfig, ModelEntryConfig, MultiModelServerConfig
 from .core.handler_process import HandlerProcessProxy
 from .core.model_registry import ModelRegistry
-from .handler import MLXFluxHandler
-from .handler.mlx_embeddings import MLXEmbeddingsHandler
-from .handler.mlx_lm import MLXLMHandler
-from .handler.mlx_vlm import MLXVLMHandler
-from .handler.mlx_whisper import MLXWhisperHandler
 from .version import __version__
 
 MFLUX_INSTALL_HINT = (
@@ -51,7 +46,7 @@ def ensure_image_handler_available(model_type: str) -> None:
     if model_type not in {"image-generation", "image-edit"}:
         return
 
-    if MLXFluxHandler is not None:
+    if importlib.util.find_spec("mflux") is not None:
         return
 
     raise RuntimeError(MFLUX_INSTALL_HINT)
@@ -70,6 +65,13 @@ _SAMPLING_DEFAULT_FIELDS: tuple[str, ...] = (
     "default_seed",
     "default_repetition_context_size",
 )
+
+
+def _clear_mlx_cache() -> None:
+    """Clear MLX cache only after a handler path actually needs MLX."""
+    import mlx.core as mx
+
+    mx.clear_cache()
 
 
 def _attach_sampling_defaults(handler: Any, config: Any) -> Any:
@@ -195,7 +197,7 @@ def create_lifespan(config_args: MLXServerConfig):
             raise
 
         # Initial memory cleanup
-        mx.clear_cache()
+        _clear_mlx_cache()
         gc.collect()
 
         yield
@@ -212,7 +214,7 @@ def create_lifespan(config_args: MLXServerConfig):
                 logger.error(f"Error during shutdown: {e!s}")
 
         # Final memory cleanup
-        mx.clear_cache()
+        _clear_mlx_cache()
         gc.collect()
 
     return lifespan
@@ -244,6 +246,8 @@ def create_handler_from_config(model_cfg: ModelEntryConfig) -> Any:
     model_path = model_cfg.model_path
 
     if model_cfg.model_type == "multimodal":
+        from .handler.mlx_vlm import MLXVLMHandler
+
         return _attach_sampling_defaults(
             MLXVLMHandler(
                 model_path=model_path,
@@ -265,6 +269,8 @@ def create_handler_from_config(model_cfg: ModelEntryConfig) -> Any:
 
     if model_cfg.model_type == "image-generation":
         ensure_image_handler_available(model_cfg.model_type)
+        from .handler.mflux import MLXFluxHandler
+
         return _attach_sampling_defaults(
             MLXFluxHandler(
                 model_path=model_path,
@@ -278,6 +284,8 @@ def create_handler_from_config(model_cfg: ModelEntryConfig) -> Any:
 
     if model_cfg.model_type == "image-edit":
         ensure_image_handler_available(model_cfg.model_type)
+        from .handler.mflux import MLXFluxHandler
+
         return _attach_sampling_defaults(
             MLXFluxHandler(
                 model_path=model_path,
@@ -290,6 +298,8 @@ def create_handler_from_config(model_cfg: ModelEntryConfig) -> Any:
         )
 
     if model_cfg.model_type == "embeddings":
+        from .handler.mlx_embeddings import MLXEmbeddingsHandler
+
         return _attach_sampling_defaults(
             MLXEmbeddingsHandler(
                 model_path=model_path,
@@ -298,6 +308,8 @@ def create_handler_from_config(model_cfg: ModelEntryConfig) -> Any:
         )
 
     if model_cfg.model_type == "whisper":
+        from .handler.mlx_whisper import MLXWhisperHandler
+
         return _attach_sampling_defaults(
             MLXWhisperHandler(
                 model_path=model_path,
@@ -306,6 +318,8 @@ def create_handler_from_config(model_cfg: ModelEntryConfig) -> Any:
         )
 
     # Default: language model ("lm")
+    from .handler.mlx_lm import MLXLMHandler
+
     return _attach_sampling_defaults(
         MLXLMHandler(
             model_path=model_path,
@@ -453,7 +467,7 @@ def create_multi_lifespan(config: MultiModelServerConfig):
             raise
 
         # Initial memory cleanup (main process only)
-        mx.clear_cache()
+        _clear_mlx_cache()
         gc.collect()
 
         yield
@@ -463,7 +477,7 @@ def create_multi_lifespan(config: MultiModelServerConfig):
         await registry.cleanup_all()
 
         # Final memory cleanup
-        mx.clear_cache()
+        _clear_mlx_cache()
         gc.collect()
 
     return lifespan
@@ -556,7 +570,7 @@ def setup_server(config_args: MLXServerConfig | MultiModelServerConfig) -> uvico
 
         # Clean up memory every 50 requests
         if request.app.state.request_count % 50 == 0:
-            mx.clear_cache()
+            _clear_mlx_cache()
             gc.collect()
             logger.debug(
                 f"Performed memory cleanup after {request.app.state.request_count} requests"

--- a/app/utils/prompt_cache.py
+++ b/app/utils/prompt_cache.py
@@ -135,6 +135,25 @@ class PromptTrie:
 
         return PromptTrieResult(None, shorter, longer, common_prefix)
 
+    def find_shorter(
+        self,
+        tokens: list[int],
+        predicate: Any,
+    ) -> list[int] | None:
+        """Find the longest strict-prefix value accepted by ``predicate``."""
+        current = self._trie
+        best: list[int] | None = None
+        prefix: list[int] = []
+        for tok in tokens[:-1]:
+            if tok not in current:
+                break
+            current = current[tok]
+            prefix.append(tok)
+            entry = current.get("__value__")
+            if entry is not None and predicate(entry):
+                best = prefix[:]
+        return best
+
 
 class LRUPromptCache:
     """Disk-backed LRU cache for MLX prompt KV caches.
@@ -165,6 +184,7 @@ class LRUPromptCache:
         nbytes: int
         cache_type: str
         trimmable: bool
+        source: str = "nonbatch"
 
     class CacheOrder:
         """Track cache recency with priority-based eviction."""
@@ -339,8 +359,19 @@ class LRUPromptCache:
     def fetch_nearest_cache(
         self,
         tokens_ids: list[int],
+        *,
+        allowed_sources: set[str] | None = None,
     ) -> tuple[list[Any] | None, list[int]]:
         """Fetch the nearest matching cache for the given token sequence.
+
+        Parameters
+        ----------
+        tokens_ids : list[int]
+            Token sequence to look up.
+        allowed_sources : set[str] | None, optional
+            Restrict hits to caches produced by these generation paths. This
+            prevents MLX cache objects created on one worker thread from being
+            reused on another worker thread.
 
         Returns
         -------
@@ -351,15 +382,22 @@ class LRUPromptCache:
         result = self._trie.search(tokens_ids)
         if result.exact is not None:
             cache_entry = self._trie.get(result.exact)
-            cache = self._try_load_cache(result.exact, cache_entry)
-            if cache is not None:
-                return cache, []
+            if self._source_allowed(cache_entry, allowed_sources):
+                cache = self._try_load_cache(result.exact, cache_entry)
+                if cache is not None:
+                    return cache, []
+            shorter = self._find_allowed_shorter(tokens_ids, allowed_sources)
+            if shorter is not None:
+                cache_entry = self._trie.get(shorter)
+                cache = self._try_load_cache(shorter, cache_entry)
+                if cache is not None:
+                    return cache, tokens_ids[len(shorter) :]
             return None, tokens_ids
 
         short_length = len(result.shorter) if result.shorter is not None else 0
         if result.longer is not None and result.common_prefix > short_length:
             cache_entry = self._trie.get(result.longer)
-            if cache_entry.trimmable:
+            if cache_entry.trimmable and self._source_allowed(cache_entry, allowed_sources):
                 cache = self._try_load_cache(result.longer, cache_entry)
                 if cache is not None:
                     prefix = min(len(tokens_ids) - 1, result.common_prefix)
@@ -368,12 +406,38 @@ class LRUPromptCache:
                     return cache, tokens_ids[prefix:]
 
         if short_length > 0:
+            shorter_tokens = result.shorter
             cache_entry = self._trie.get(result.shorter)
-            cache = self._try_load_cache(result.shorter, cache_entry)
+            if not self._source_allowed(cache_entry, allowed_sources):
+                shorter_tokens = self._find_allowed_shorter(tokens_ids, allowed_sources)
+                if shorter_tokens is None:
+                    return None, tokens_ids
+                cache_entry = self._trie.get(shorter_tokens)
+                short_length = len(shorter_tokens)
+            cache = self._try_load_cache(shorter_tokens, cache_entry)
             if cache is not None:
                 return cache, tokens_ids[short_length:]
 
         return None, tokens_ids
+
+    def _source_allowed(
+        self,
+        entry: CacheEntry,
+        allowed_sources: set[str] | None,
+    ) -> bool:
+        """Return whether an entry may be used by the current generation path."""
+        return allowed_sources is None or entry.source in allowed_sources
+
+    def _find_allowed_shorter(
+        self,
+        tokens_ids: list[int],
+        allowed_sources: set[str] | None,
+    ) -> list[int] | None:
+        """Find the longest allowed strict-prefix cache entry."""
+        return self._trie.find_shorter(
+            tokens_ids,
+            lambda entry: self._source_allowed(entry, allowed_sources),
+        )
 
     def insert_cache(
         self,
@@ -381,6 +445,7 @@ class LRUPromptCache:
         prompt_cache: list[Any],
         *,
         cache_type: str = "assistant",
+        source: str = "nonbatch",
     ) -> None:
         """Insert or update a cache entry.
 
@@ -392,6 +457,8 @@ class LRUPromptCache:
             The prompt cache data to store.
         cache_type : str, optional
             Priority category for eviction ordering, by default ``"assistant"``.
+        source : str, optional
+            Generation path that produced the cache, by default ``"nonbatch"``.
         """
         tokens_tuple = tuple(tokens_ids)
 
@@ -401,6 +468,7 @@ class LRUPromptCache:
             sum(getattr(c, "nbytes", 0) for c in prompt_cache),
             cache_type,
             can_trim_prompt_cache(prompt_cache),
+            source,
         )
 
         # Insert into the trie and update the byte counter and lru position

--- a/tests/test_batch_scheduler.py
+++ b/tests/test_batch_scheduler.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import asyncio
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+import importlib
+import sys
 import threading
+import types
 from typing import Any
 
 import pytest
@@ -406,15 +409,36 @@ def test_admission_queue_accepts_before_start(patched_scheduler):
 
 
 # ---------------------------------------------------------------------------
-# Regression: seed=0 (the CLI default that the endpoint backfills into every
-# request) must NOT disable batching. If it does, every request is routed
-# through the single-request path and the scheduler never sees concurrent
-# work.
+# Regression: per-request seeds must NOT disable batching. Operators who need
+# positive request seeds honored must opt into the single-request path with
+# --disable-batching.
 # ---------------------------------------------------------------------------
 
 
-def test_default_seed_zero_does_not_disable_batching():
-    from app.handler.mlx_lm import MLXLMHandler
+def _load_handler_module_for_batchability(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Import the LM handler with MLX-backed core modules stubbed."""
+    fake_core = types.ModuleType("app.core")
+    fake_batch_scheduler = types.ModuleType("app.core.batch_scheduler")
+
+    class _FakeBatchScheduler:
+        pass
+
+    class _FakeInferenceWorker:
+        pass
+
+    fake_core.BatchScheduler = _FakeBatchScheduler
+    fake_core.InferenceWorker = _FakeInferenceWorker
+    fake_batch_scheduler.BATCHING_AVAILABLE = True
+
+    monkeypatch.setitem(sys.modules, "app.core", fake_core)
+    monkeypatch.setitem(sys.modules, "app.core.batch_scheduler", fake_batch_scheduler)
+    sys.modules.pop("app.handler.mlx_lm", None)
+
+    return importlib.import_module("app.handler.mlx_lm")
+
+
+def test_request_seed_does_not_disable_batching(monkeypatch):
+    handler_module = _load_handler_module_for_batchability(monkeypatch)
 
     class _FakeModel:
         has_draft_model = False
@@ -424,18 +448,36 @@ def test_default_seed_zero_does_not_disable_batching():
         def __init__(self, seed):
             self.seed = seed
 
-    handler = MLXLMHandler.__new__(MLXLMHandler)
+    handler = handler_module.MLXLMHandler.__new__(handler_module.MLXLMHandler)
     handler.model = _FakeModel()
+    handler._disable_batching = False
 
     assert handler._is_request_batchable(_Req(seed=None)) is True
     assert handler._is_request_batchable(_Req(seed=0)) is True
     assert handler._is_request_batchable(_Req(seed=-1)) is True
-    assert handler._is_request_batchable(_Req(seed=42)) is False
+    assert handler._is_request_batchable(_Req(seed=42)) is True
 
 
-def test_non_mergeable_cache_disables_batching():
+def test_disable_batching_routes_to_single_request_path(monkeypatch):
+    handler_module = _load_handler_module_for_batchability(monkeypatch)
+
+    class _FakeModel:
+        has_draft_model = False
+        cache_is_batchable = True
+
+    class _Req:
+        seed = None
+
+    handler = handler_module.MLXLMHandler.__new__(handler_module.MLXLMHandler)
+    handler.model = _FakeModel()
+    handler._disable_batching = True
+
+    assert handler._is_request_batchable(_Req()) is False
+
+
+def test_non_mergeable_cache_disables_batching(monkeypatch):
     """Models whose prompt caches don't expose ``merge`` must fall back."""
-    from app.handler.mlx_lm import MLXLMHandler
+    handler_module = _load_handler_module_for_batchability(monkeypatch)
 
     class _FakeModel:
         has_draft_model = False
@@ -444,8 +486,9 @@ def test_non_mergeable_cache_disables_batching():
     class _Req:
         seed = None
 
-    handler = MLXLMHandler.__new__(MLXLMHandler)
+    handler = handler_module.MLXLMHandler.__new__(handler_module.MLXLMHandler)
     handler.model = _FakeModel()
+    handler._disable_batching = False
 
     assert handler._is_request_batchable(_Req()) is False
 

--- a/tests/test_inference_worker.py
+++ b/tests/test_inference_worker.py
@@ -1,0 +1,49 @@
+"""Tests for :class:`app.core.inference_worker.InferenceWorker`."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import threading
+import types
+from typing import Any
+
+import pytest
+
+from app.core.inference_worker import InferenceWorker
+
+
+@pytest.mark.asyncio
+async def test_submit_runs_inside_worker_thread_local_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Submitted work should execute inside the worker-owned MLX stream context."""
+    fake_mlx = types.ModuleType("mlx")
+    fake_mx = types.ModuleType("mlx.core")
+    local = threading.local()
+    stream_obj = object()
+
+    fake_mx.default_device = lambda: "gpu"
+    fake_mx.new_thread_local_stream = lambda device: stream_obj
+
+    @contextmanager
+    def fake_stream(stream: object) -> Any:
+        local.active_stream = stream
+        try:
+            yield
+        finally:
+            local.active_stream = None
+
+    fake_mx.stream = fake_stream
+    fake_mlx.core = fake_mx
+    monkeypatch.setitem(__import__("sys").modules, "mlx", fake_mlx)
+    monkeypatch.setitem(__import__("sys").modules, "mlx.core", fake_mx)
+
+    worker = InferenceWorker()
+    worker.start()
+    try:
+        result = await worker.submit(lambda: local.active_stream is stream_obj)
+    finally:
+        worker.stop()
+
+    assert result is True
+    assert worker._stream is stream_obj

--- a/tests/test_inference_worker.py
+++ b/tests/test_inference_worker.py
@@ -41,9 +41,11 @@ async def test_submit_runs_inside_worker_thread_local_stream(
     worker = InferenceWorker()
     worker.start()
     try:
-        result = await worker.submit(lambda: local.active_stream is stream_obj)
+        result = await worker.submit(
+            lambda: local.active_stream is stream_obj and worker._stream is stream_obj
+        )
     finally:
         worker.stop()
 
     assert result is True
-    assert worker._stream is stream_obj
+    assert worker._stream is None

--- a/tests/test_non_trimmable_checkpoint.py
+++ b/tests/test_non_trimmable_checkpoint.py
@@ -335,6 +335,7 @@ class TestModelCheckpointPrefill:
         monkeypatch.setitem(sys.modules, "mlx_lm.sample_utils", fake_sample)
 
         fake_utils = types.ModuleType("mlx_lm.utils")
+        fake_utils._download = Mock()
         fake_utils.load = Mock()
         monkeypatch.setitem(sys.modules, "mlx_lm.utils", fake_utils)
 
@@ -371,6 +372,7 @@ class TestModelCheckpointPrefill:
         model.bos_token = "<s>"
         model.model_type = "test"
         model.debug = False
+        model.generation_config = {}
         model.outlines_tokenizer = Mock()
         model._cache_is_trimmable = False
         model._num_model_cache_layers = 2
@@ -559,3 +561,65 @@ class TestCheckpointOnShorterCacheHit:
         # If cached_prefix_len >= boundary, no checkpoint should be set
         cached_prefix_len = boundary + 5
         assert cached_prefix_len >= boundary, "Cached prefix covers the boundary"
+
+
+class TestNonBatchExactCacheHit:
+    """Verify fallback generation never receives an empty prompt suffix."""
+
+    def _make_handler(self, monkeypatch: pytest.MonkeyPatch) -> Any:
+        """Create a handler with a fake prompt cache for exact-hit tests."""
+        MLXLMHandler = _load_handler_class(monkeypatch)
+        handler = MLXLMHandler.__new__(MLXLMHandler)
+        handler.prompt_cache = Mock()
+        return handler
+
+    def test_discards_unbackable_exact_hit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Non-trimmable exact hits without a shorter checkpoint fall back to full prefill."""
+        handler = self._make_handler(monkeypatch)
+        input_ids = [1, 2, 3, 4]
+        exact_cache = [Mock(state=[])]
+        handler.prompt_cache.fetch_nearest_cache.return_value = (None, input_ids[:-1])
+
+        cache, rest = handler._normalize_nonbatch_cache_hit(input_ids, exact_cache, [])
+
+        assert cache is None
+        assert rest == input_ids
+
+    def test_uses_shorter_checkpoint_for_exact_hit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A shorter checkpoint can back off a non-trimmable exact cache hit."""
+        handler = self._make_handler(monkeypatch)
+        input_ids = [1, 2, 3, 4]
+        exact_cache = [Mock(state=[])]
+        prefix_cache = [Mock(state=[])]
+        handler.prompt_cache.fetch_nearest_cache.return_value = (prefix_cache, [])
+
+        cache, rest = handler._normalize_nonbatch_cache_hit(input_ids, exact_cache, [])
+
+        assert cache is prefix_cache
+        assert rest == [4]
+
+    def test_trims_trimmable_exact_hit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Trimmable exact hits are backed off by one token in-place."""
+        handler = self._make_handler(monkeypatch)
+        cache_module = sys.modules["mlx_lm.models.cache"]
+        trim_calls: list[tuple[Any, int]] = []
+        cache_module.can_trim_prompt_cache = lambda _cache: True
+        cache_module.trim_prompt_cache = lambda cache, n: trim_calls.append((cache, n))
+
+        input_ids = [1, 2, 3, 4]
+        exact_cache = [Mock(state=[])]
+
+        cache, rest = handler._normalize_nonbatch_cache_hit(input_ids, exact_cache, [])
+
+        assert cache is exact_cache
+        assert rest == [4]
+        assert trim_calls == [(exact_cache, 1)]

--- a/tests/test_prompt_cache_cancellation.py
+++ b/tests/test_prompt_cache_cancellation.py
@@ -12,6 +12,7 @@ import types
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
+from fastapi import HTTPException
 import pytest
 
 
@@ -64,6 +65,22 @@ def _load_handler_class(monkeypatch: pytest.MonkeyPatch) -> type[Any]:
     return handler_module.MLXLMHandler
 
 
+def _submit_stream_on_current_thread(*args: Any, **kwargs: Any) -> AsyncGenerator[Any, None]:
+    """Run a stream worker function and expose it as an async generator."""
+    func = args[0]
+    func_args = args[1:]
+
+    async def _gen() -> AsyncGenerator[Any, None]:
+        stream = func(*func_args, **kwargs)
+        try:
+            for item in stream:
+                yield item
+        finally:
+            stream.close()
+
+    return _gen()
+
+
 @pytest.mark.asyncio
 async def test_prompt_cache_inserted_on_stream_cancellation(
     monkeypatch: pytest.MonkeyPatch,
@@ -79,20 +96,17 @@ async def test_prompt_cache_inserted_on_stream_cancellation(
     mock_model.encode_prompt.return_value = [1, 2, 3]
     mock_model.create_prompt_cache.return_value = Mock(name="cache_obj")
 
+    chunk = Mock()
+    chunk.text = "Hello"
+    chunk.token = 4
+    mock_model.side_effect = lambda *_args, **_kwargs: iter([chunk])
+
     mock_inference_worker = Mock()
-
-    async def mock_response_gen() -> AsyncGenerator[Mock, None]:
-        chunk = Mock()
-        chunk.text = "Hello"
-        chunk.token = 4
-        yield chunk
-
-    mock_inference_worker.submit_stream = Mock(
-        side_effect=lambda *args, **kwargs: mock_response_gen()
-    )
+    mock_inference_worker.submit_stream = Mock(side_effect=_submit_stream_on_current_thread)
 
     mock_prompt_cache = Mock()
-    mock_prompt_cache.fetch_nearest_cache.return_value = (Mock(name="cache_obj"), [])
+    cached_prompt = [Mock(name="cache_obj")]
+    mock_prompt_cache.fetch_nearest_cache.return_value = (cached_prompt, [])
 
     mlx_lm_handler = _load_handler_class(monkeypatch)
     handler = mlx_lm_handler.__new__(mlx_lm_handler)
@@ -107,6 +121,7 @@ async def test_prompt_cache_inserted_on_stream_cancellation(
     handler.model_type = "text"
     handler.enable_auto_tool_choice = False
     handler.message_converter = Mock()
+    handler._generation_lock = __import__("threading").RLock()
 
     # Mock internal methods
     handler._prepare_text_request = AsyncMock(return_value=([], {}))
@@ -126,15 +141,10 @@ async def test_prompt_cache_inserted_on_stream_cancellation(
         finally:
             # Explicitly close the generator to trigger GeneratorExit.
             await gen.aclose()
+            await asyncio.sleep(0)
 
-        # After cancellation, the cache should be inserted exactly once.
-        mock_prompt_cache.insert_cache.assert_called_once()
-        # Verify the cache_key includes the initial input_ids and the token from the chunk.
-        call_args = mock_prompt_cache.insert_cache.call_args
-        inserted_key = call_args[0][0]
-        inserted_cache = call_args[0][1]
-        assert inserted_key == [1, 2, 3, 4]
-        assert inserted_cache is mock_prompt_cache.fetch_nearest_cache.return_value[0]
+        submitted = mock_inference_worker.submit_stream.call_args[0]
+        assert submitted[0].__name__ == "_stream_with_lock_and_cache_persist"
 
 
 @pytest.mark.asyncio
@@ -148,24 +158,23 @@ async def test_prompt_cache_inserted_on_normal_completion(
     mock_model.encode_prompt.return_value = input_ids
     mock_model.create_prompt_cache.return_value = Mock(name="cache_obj")
 
+    chunks = []
+    for token in [4, 5, 6]:
+        chunk = Mock()
+        chunk.text = f"Token {token}"
+        chunk.token = token
+        if token == 6:
+            chunk.prompt_tokens = 10
+            chunk.generation_tokens = 20
+        chunks.append(chunk)
+    mock_model.side_effect = lambda *_args, **_kwargs: iter(chunks)
+
     mock_inference_worker = Mock()
-
-    async def mock_response_gen() -> AsyncGenerator[Mock, None]:
-        for token in [4, 5, 6]:
-            chunk = Mock()
-            chunk.text = f"Token {token}"
-            chunk.token = token
-            if token == 6:
-                chunk.prompt_tokens = 10
-                chunk.generation_tokens = 20
-            yield chunk
-
-    mock_inference_worker.submit_stream = Mock(
-        side_effect=lambda *args, **kwargs: mock_response_gen()
-    )
+    mock_inference_worker.submit_stream = Mock(side_effect=_submit_stream_on_current_thread)
 
     mock_prompt_cache = Mock()
-    mock_prompt_cache.fetch_nearest_cache.return_value = (Mock(name="cache_obj"), [])
+    cached_prompt = [Mock(name="cache_obj")]
+    mock_prompt_cache.fetch_nearest_cache.return_value = (cached_prompt, [])
 
     mlx_lm_handler = _load_handler_class(monkeypatch)
     handler = mlx_lm_handler.__new__(mlx_lm_handler)
@@ -180,6 +189,7 @@ async def test_prompt_cache_inserted_on_normal_completion(
     handler.model_type = "text"
     handler.enable_auto_tool_choice = False
     handler.message_converter = Mock()
+    handler._generation_lock = __import__("threading").RLock()
 
     handler._prepare_text_request = AsyncMock(return_value=([], {}))
     handler.refine_messages = Mock(return_value=[])
@@ -196,13 +206,14 @@ async def test_prompt_cache_inserted_on_normal_completion(
                 pass
         finally:
             await gen.aclose()
+            await asyncio.sleep(0)
 
         mock_prompt_cache.insert_cache.assert_called_once()
         call_args = mock_prompt_cache.insert_cache.call_args
         inserted_key = call_args[0][0]
         inserted_cache = call_args[0][1]
         assert inserted_key == [1, 2, 3, 4, 5, 6]
-        assert inserted_cache is mock_prompt_cache.fetch_nearest_cache.return_value[0]
+        assert inserted_cache is cached_prompt
 
 
 @pytest.mark.asyncio
@@ -216,18 +227,14 @@ async def test_prompt_cache_inserted_on_cancellation_before_any_chunk(
     mock_model.encode_prompt.return_value = input_ids
     mock_model.create_prompt_cache.return_value = Mock(name="cache_obj")
 
+    mock_model.side_effect = lambda *_args, **_kwargs: iter([])
+
     mock_inference_worker = Mock()
-
-    async def blocked_response_gen() -> AsyncGenerator[None, None]:
-        await asyncio.Event().wait()
-        yield  # unreachable, but makes it an async generator
-
-    mock_inference_worker.submit_stream = Mock(
-        side_effect=lambda *args, **kwargs: blocked_response_gen()
-    )
+    mock_inference_worker.submit_stream = Mock(side_effect=_submit_stream_on_current_thread)
 
     mock_prompt_cache = Mock()
-    mock_prompt_cache.fetch_nearest_cache.return_value = (Mock(name="cache_obj"), [])
+    cached_prompt = [Mock(name="cache_obj")]
+    mock_prompt_cache.fetch_nearest_cache.return_value = (cached_prompt, [])
 
     mlx_lm_handler = _load_handler_class(monkeypatch)
     handler = mlx_lm_handler.__new__(mlx_lm_handler)
@@ -242,6 +249,7 @@ async def test_prompt_cache_inserted_on_cancellation_before_any_chunk(
     handler.model_type = "text"
     handler.enable_auto_tool_choice = False
     handler.message_converter = Mock()
+    handler._generation_lock = __import__("threading").RLock()
 
     handler._prepare_text_request = AsyncMock(return_value=([], {}))
     handler.refine_messages = Mock(return_value=[])
@@ -256,7 +264,7 @@ async def test_prompt_cache_inserted_on_cancellation_before_any_chunk(
         task = asyncio.create_task(gen.__anext__())
         await asyncio.sleep(0)
         task.cancel()
-        with suppress(asyncio.CancelledError, StopAsyncIteration, GeneratorExit):
+        with suppress(asyncio.CancelledError, StopAsyncIteration, GeneratorExit, HTTPException):
             await task
         await gen.aclose()
 
@@ -265,7 +273,7 @@ async def test_prompt_cache_inserted_on_cancellation_before_any_chunk(
         inserted_key = call_args[0][0]
         inserted_cache = call_args[0][1]
         assert inserted_key == [1, 2, 3]
-        assert inserted_cache is mock_prompt_cache.fetch_nearest_cache.return_value[0]
+        assert inserted_cache is cached_prompt
 
 
 @pytest.mark.asyncio
@@ -279,21 +287,20 @@ async def test_prompt_cache_inserted_on_cancellation_after_multiple_chunks(
     mock_model.encode_prompt.return_value = input_ids
     mock_model.create_prompt_cache.return_value = Mock(name="cache_obj")
 
+    chunks = []
+    for token in [4, 5, 6]:
+        chunk = Mock()
+        chunk.text = f"Token {token}"
+        chunk.token = token
+        chunks.append(chunk)
+    mock_model.side_effect = lambda *_args, **_kwargs: iter(chunks)
+
     mock_inference_worker = Mock()
-
-    async def mock_response_gen() -> AsyncGenerator[Mock, None]:
-        for token in [4, 5, 6]:
-            chunk = Mock()
-            chunk.text = f"Token {token}"
-            chunk.token = token
-            yield chunk
-
-    mock_inference_worker.submit_stream = Mock(
-        side_effect=lambda *args, **kwargs: mock_response_gen()
-    )
+    mock_inference_worker.submit_stream = Mock(side_effect=_submit_stream_on_current_thread)
 
     mock_prompt_cache = Mock()
-    mock_prompt_cache.fetch_nearest_cache.return_value = (Mock(name="cache_obj"), [])
+    cached_prompt = [Mock(name="cache_obj")]
+    mock_prompt_cache.fetch_nearest_cache.return_value = (cached_prompt, [])
 
     mlx_lm_handler = _load_handler_class(monkeypatch)
     handler = mlx_lm_handler.__new__(mlx_lm_handler)
@@ -308,6 +315,7 @@ async def test_prompt_cache_inserted_on_cancellation_after_multiple_chunks(
     handler.model_type = "text"
     handler.enable_auto_tool_choice = False
     handler.message_converter = Mock()
+    handler._generation_lock = __import__("threading").RLock()
 
     handler._prepare_text_request = AsyncMock(return_value=([], {}))
     handler.refine_messages = Mock(return_value=[])
@@ -328,9 +336,35 @@ async def test_prompt_cache_inserted_on_cancellation_after_multiple_chunks(
         finally:
             await gen.aclose()
 
-        mock_prompt_cache.insert_cache.assert_called_once()
-        call_args = mock_prompt_cache.insert_cache.call_args
-        inserted_key = call_args[0][0]
-        inserted_cache = call_args[0][1]
-        assert inserted_key == [1, 2, 3, 4, 5]
-        assert inserted_cache is mock_prompt_cache.fetch_nearest_cache.return_value[0]
+        submitted = mock_inference_worker.submit_stream.call_args[0]
+        assert submitted[0].__name__ == "_stream_with_lock_and_cache_persist"
+
+
+def test_worker_stream_wrapper_persists_cache_on_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The worker-side stream wrapper persists cache when the stream is closed."""
+    mlx_lm_handler = _load_handler_class(monkeypatch)
+    handler = mlx_lm_handler.__new__(mlx_lm_handler)
+    handler._generation_lock = __import__("threading").RLock()
+    handler.prompt_cache = Mock()
+
+    chunks = []
+    for token in [4, 5]:
+        chunk = Mock()
+        chunk.token = token
+        chunks.append(chunk)
+    handler.model = Mock(side_effect=lambda *_args, **_kwargs: iter(chunks))
+
+    cache = [Mock(name="cache_obj")]
+    stream = handler._stream_with_lock_and_cache_persist(
+        [1, 2, 3],
+        cache,
+        input_ids=[3],
+        prompt_cache=cache,
+        stream=True,
+    )
+
+    first = next(stream)
+    assert first.token == 4
+    stream.close()
+
+    handler.prompt_cache.insert_cache.assert_called_once_with([1, 2, 3, 4], cache)

--- a/tests/test_prompt_cache_disk.py
+++ b/tests/test_prompt_cache_disk.py
@@ -106,3 +106,55 @@ def test_prompt_cache_longer_hit_loads_and_trims_from_disk(
     assert rest == [9]
     assert result is not None
     assert [layer.value for layer in result] == ["one", "two"]
+
+
+def test_prompt_cache_source_filter_skips_cross_thread_exact_hit(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    """Source filtering should prevent batch caches from blocking nonbatch lookup."""
+    prompt_cache_module = _load_prompt_cache_module(monkeypatch, trimmable=False)
+    cache = prompt_cache_module.LRUPromptCache(max_size=10, cache_dir=tmp_path)
+
+    cache.insert_cache(
+        [1, 2],
+        [_FakeCacheLayer("nonbatch-prefix")],
+        source="nonbatch",
+    )
+    cache.insert_cache(
+        [1, 2, 3],
+        [_FakeCacheLayer("batch-exact")],
+        source="batch",
+    )
+
+    result, rest = cache.fetch_nearest_cache(
+        [1, 2, 3],
+        allowed_sources={"nonbatch"},
+    )
+
+    assert rest == [3]
+    assert result is not None
+    assert result[0].value == "nonbatch-prefix"
+
+
+def test_prompt_cache_source_filter_returns_miss_for_disallowed_only_hit(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    """A cache entry from another generation path should be invisible."""
+    prompt_cache_module = _load_prompt_cache_module(monkeypatch, trimmable=False)
+    cache = prompt_cache_module.LRUPromptCache(max_size=10, cache_dir=tmp_path)
+
+    cache.insert_cache(
+        [1, 2, 3],
+        [_FakeCacheLayer("batch-exact")],
+        source="batch",
+    )
+
+    result, rest = cache.fetch_nearest_cache(
+        [1, 2, 3],
+        allowed_sources={"nonbatch"},
+    )
+
+    assert result is None
+    assert rest == [1, 2, 3]


### PR DESCRIPTION
## Summary

Fix LM generation thread-affinity issues around continuous batching, non-batch fallback, and prompt-cache persistence.

Fixes https://github.com/cubist38/mlx-openai-server/issues/290.

- Add `--disable-batching` / `disable_batching` for users who need single-request generation behavior, including positive per-request `seed` values.
- Keep seed-bearing LM requests on the batch path when batching is enabled; positive request seeds are ignored with a warning instead of forcing non-batch fallback.
- Persist non-batch prompt caches on the inference worker thread, not the async handler thread, to avoid MLX stream-affinity failures.
- Give `InferenceWorker` its own worker-thread MLX stream using `new_thread_local_stream(mx.default_device())` when available, with a `new_stream` fallback.
- Partition prompt-cache reuse by producer path (`batch` vs `nonbatch`) so MLX cache payloads are not shared across generation threads.
- Lazy-load VLM/image/MLX-heavy modules so LM-only launch does not import `av`, `cv2`, `mflux`, or `mlx.core` at startup.
- Document the batching seed policy and MLX stream-affinity troubleshooting guidance.

## Why

Mixed batch/non-batch traffic could hit MLX thread-affinity errors such as:

```text
There is no Stream(gpu, N) in current thread.
```

The immediate issue was that prompt caches mutated on the inference worker thread were later serialized from the event-loop thread. A related issue was that batch-created prompt-cache payloads could be reused by non-batch generation, crossing MLX stream/thread ownership boundaries.

The new behavior makes generation ownership explicit:

- batch generation owns batch cache entries;
- non-batch generation owns non-batch cache entries;
- cache persistence happens on the same worker thread that performed generation;
- request seed reproducibility is available through `--disable-batching` rather than per-request fallback.

## Testing

```bash
./.venv/bin/python -m pytest tests/test_inference_worker.py tests/test_prompt_cache_cancellation.py tests/test_prompt_cache_disk.py tests/test_non_trimmable_checkpoint.py tests/test_batch_scheduler.py::test_request_seed_does_not_disable_batching tests/test_batch_scheduler.py::test_disable_batching_routes_to_single_request_path tests/test_batch_scheduler.py::test_non_mergeable_cache_disables_batching -q
```

```bash
./.venv/bin/ruff check app/core/inference_worker.py app/cli.py app/server.py app/handler/mlx_lm.py app/core/batch_scheduler.py app/utils/prompt_cache.py app/api/endpoints.py app/core/__init__.py tests/test_inference_worker.py tests/test_prompt_cache_cancellation.py
```

Also verified that importing `app.cli` and `app.server` no longer loads `cv2`, `av`, `mflux`, or `mlx.core`.