### PR TITLE
Feat/mlx vlm batch scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,11 @@ LM-specific memory and batching options:
 | `--draft-model-path` | unset | Smaller draft model for speculative decoding |
 | `--num-draft-tokens` | `2` | Draft tokens proposed per step |
 
-When continuous batching is enabled, LM requests stay on the batched generation path whenever the model supports batched KV-cache merging. Per-request positive `seed` values are ignored in this mode because the batch scheduler shares one RNG lane; launch with `--disable-batching` if request-level seed reproducibility is required.
+When continuous batching is enabled, LM and multimodal requests stay on the batched generation path whenever the backend supports it. Per-request positive `seed` values are ignored in this mode because the batch scheduler shares one RNG lane; launch with `--disable-batching` if request-level seed reproducibility is required.
 
 Prompt KV caches are reused only by the generation path that created them. Batched and non-batched requests use separate cache entries because MLX cache and stream objects are thread-affine.
+
+Multimodal (`mlx-vlm`) batching intentionally does not use prompt-prefix caching; current mlx-vlm prompt-cache support is limited, so VLM batching focuses on admitting parallel requests into the shared decode/prefill batch.
 
 ## Multi-Model Config
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -319,7 +319,7 @@ def cli():
     type=int,
     help=(
         "When a request is batchable, decode that many requests in parallel. "
-        "Only applies to 'lm' model types. Default is 32."
+        "Applies to 'lm' and 'multimodal' model types. Default is 32."
     ),
 )
 @click.option(
@@ -329,7 +329,7 @@ def cli():
     type=int,
     help=(
         "When a request is batchable, prefill that many prompts in parallel. "
-        "Only applies to 'lm' model types. Default is 8."
+        "Applies to 'lm' and 'multimodal' model types. Default is 8."
     ),
 )
 @click.option(
@@ -339,7 +339,7 @@ def cli():
     type=int,
     help=(
         "Maximum tokens processed per prefill step during batched generation. "
-        "Only applies to 'lm' model types. Default is 2048."
+        "Applies to 'lm' and 'multimodal' model types. Default is 2048."
     ),
 )
 @click.option(
@@ -347,7 +347,7 @@ def cli():
     is_flag=True,
     default=False,
     help=(
-        "Disable continuous batching for LM models. Use this when per-request "
+        "Disable continuous batching for LM/VLM models. Use this when per-request "
         "positive seeds must be honored."
     ),
 )

--- a/app/core/vlm_batch_scheduler.py
+++ b/app/core/vlm_batch_scheduler.py
@@ -1,0 +1,527 @@
+"""Continuous-batch scheduler for ``mlx-vlm`` multimodal generation."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator, Callable
+from dataclasses import dataclass
+import queue
+import threading
+import time
+from typing import Any
+
+from loguru import logger
+import mlx.core as mx
+
+try:
+    from mlx_vlm.generate import (
+        DEFAULT_KV_GROUP_SIZE,
+        DEFAULT_KV_QUANT_SCHEME,
+        DEFAULT_QUANTIZED_KV_START,
+        BatchGenerator,
+    )
+
+    VLM_BATCHING_AVAILABLE = True
+except (ImportError, RuntimeError) as exc:  # pragma: no cover - optional backend
+    DEFAULT_KV_GROUP_SIZE = 64
+    DEFAULT_KV_QUANT_SCHEME = "uniform"
+    DEFAULT_QUANTIZED_KV_START = 0
+    BatchGenerator = None  # type: ignore[assignment,misc]
+    VLM_BATCHING_AVAILABLE = False
+    logger.warning(
+        "mlx_vlm.generate.BatchGenerator is unavailable; multimodal continuous "
+        f"batching is disabled. Upgrade mlx-vlm to enable VLM batching: {exc!s}"
+    )
+
+
+@dataclass
+class VLMBatchChunk:
+    """Per-request chunk emitted by :class:`VLMBatchScheduler`.
+
+    Parameters
+    ----------
+    text : str
+        Incremental decoded text segment since the previous chunk.
+    token : int
+        Sampled token id for this step.
+    finish_reason : str | None
+        ``None`` while generation is in progress, otherwise the terminal
+        reason reported by ``mlx-vlm``.
+    generation_tokens : int
+        Number of generated tokens for this request.
+    generation_tps : float
+        Average generation tokens per second, populated on terminal chunks.
+    prompt_tokens : int
+        Number of prompt tokens processed for the request.
+    prompt_tps : float
+        Prompt processing tokens per second, populated from ``BatchGenerator``
+        aggregate stats on terminal chunks when available.
+    peak_memory : float
+        Peak MLX memory in GB, populated on terminal chunks.
+    """
+
+    text: str
+    token: int
+    finish_reason: str | None = None
+    generation_tokens: int = 0
+    generation_tps: float = 0.0
+    prompt_tokens: int = 0
+    prompt_tps: float = 0.0
+    peak_memory: float = 0.0
+
+
+@dataclass
+class _PendingVLMRequest:
+    """Queued multimodal request waiting to enter the VLM batch."""
+
+    raw_inputs: dict[str, Any]
+    prompt_tokens: int
+    max_tokens: int
+    sampler: Callable[[mx.array], mx.array] | None
+    logits_processors: list[Callable[[mx.array, mx.array], mx.array]] | None
+    loop: asyncio.AbstractEventLoop
+    out_queue: asyncio.Queue[Any]
+    cancel_event: threading.Event
+
+
+@dataclass
+class _ActiveVLMRequest:
+    """State tracked for a live multimodal sequence."""
+
+    loop: asyncio.AbstractEventLoop
+    out_queue: asyncio.Queue[Any]
+    cancel_event: threading.Event
+    prompt_tokens: int
+    tokens: list[int]
+    previous_text: str = ""
+    first_token_time: float | None = None
+
+
+_STREAM_SENTINEL: Any = object()
+
+
+class VLMBatchScheduler:
+    """Continuous-batch scheduler backed by ``mlx_vlm.generate.BatchGenerator``.
+
+    The full multimodal model is used only to build input embeddings on this
+    scheduler thread. The underlying ``BatchGenerator`` then batches the
+    model's language model exactly as the upstream ``mlx-vlm`` server does.
+    Prompt-prefix caching is intentionally not implemented because mlx-vlm's
+    cache support is immature and cross-thread cache reuse is fragile.
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        processor: Any,
+        *,
+        completion_batch_size: int = 32,
+        prefill_batch_size: int = 8,
+        prefill_step_size: int = 2048,
+        kv_bits: int | None = None,
+        kv_group_size: int = DEFAULT_KV_GROUP_SIZE,
+        kv_quant_scheme: str = DEFAULT_KV_QUANT_SCHEME,
+        quantized_kv_start: int = DEFAULT_QUANTIZED_KV_START,
+        queue_size: int = 100,
+        idle_poll_timeout: float = 0.1,
+    ) -> None:
+        self._model = model
+        self._language_model = getattr(model, "language_model", model)
+        self._processor = processor
+        self._tokenizer = processor.tokenizer if hasattr(processor, "tokenizer") else processor
+        self._completion_batch_size = completion_batch_size
+        self._prefill_batch_size = prefill_batch_size
+        self._prefill_step_size = prefill_step_size
+        self._kv_bits = kv_bits
+        self._kv_group_size = kv_group_size
+        self._kv_quant_scheme = kv_quant_scheme
+        self._quantized_kv_start = quantized_kv_start
+        self._queue_size = queue_size
+        self._idle_poll_timeout = idle_poll_timeout
+
+        self._admission_queue: queue.Queue[_PendingVLMRequest] = queue.Queue(maxsize=queue_size)
+        self._batch_generator: Any | None = None
+        self._active: dict[int, _ActiveVLMRequest] = {}
+        self._stream: Any | None = None
+        self._thread: threading.Thread | None = None
+        self._running = False
+        self._state_lock = threading.Lock()
+        self._ready_event = threading.Event()
+        self._start_error: BaseException | None = None
+        self._stop_tokens = self._resolve_stop_tokens()
+
+    @property
+    def is_running(self) -> bool:
+        """Return whether the scheduler worker thread is active."""
+        return self._running
+
+    def start(self) -> None:
+        """Start the VLM batch scheduler thread."""
+        with self._state_lock:
+            if self._running:
+                return
+            if BatchGenerator is None:
+                raise RuntimeError(
+                    "mlx_vlm.generate.BatchGenerator is not available in the "
+                    "installed mlx-vlm; upgrade mlx-vlm to enable VLM batching."
+                )
+            self._ready_event.clear()
+            self._start_error = None
+            self._running = True
+            self._thread = threading.Thread(
+                target=self._run, daemon=True, name="mlx-vlm-batch-scheduler"
+            )
+            self._thread.start()
+
+        if not self._ready_event.wait(timeout=60.0):
+            with self._state_lock:
+                self._running = False
+            raise RuntimeError("VLMBatchScheduler did not initialize within 60s")
+        if self._start_error is not None:
+            raise self._start_error
+        logger.info(
+            "VLMBatchScheduler started (completion={}, prefill={}, prefill_step={})",
+            self._completion_batch_size,
+            self._prefill_batch_size,
+            self._prefill_step_size,
+        )
+
+    def stop(self) -> None:
+        """Stop the scheduler and fail pending requests."""
+        with self._state_lock:
+            if not self._running:
+                return
+            self._running = False
+            thread = self._thread
+            self._thread = None
+        if thread is not None:
+            thread.join(timeout=10.0)
+        logger.info("VLMBatchScheduler stopped")
+
+    def submit_stream(
+        self,
+        raw_inputs: dict[str, Any],
+        *,
+        prompt_tokens: int,
+        max_tokens: int,
+        sampler: Callable[[mx.array], mx.array] | None = None,
+        logits_processors: list[Callable[[mx.array, mx.array], mx.array]] | None = None,
+    ) -> AsyncGenerator[VLMBatchChunk, None]:
+        """Submit one multimodal request to the continuous batcher."""
+        if not self._running:
+            raise RuntimeError("VLMBatchScheduler is not running; call start() first")
+
+        loop = asyncio.get_running_loop()
+        out_queue: asyncio.Queue[Any] = asyncio.Queue()
+        cancel_event = threading.Event()
+        request = _PendingVLMRequest(
+            raw_inputs=dict(raw_inputs),
+            prompt_tokens=prompt_tokens,
+            max_tokens=max_tokens,
+            sampler=sampler,
+            logits_processors=logits_processors,
+            loop=loop,
+            out_queue=out_queue,
+            cancel_event=cancel_event,
+        )
+        try:
+            self._admission_queue.put_nowait(request)
+        except queue.Full as exc:
+            raise asyncio.QueueFull("VLMBatchScheduler admission queue is full") from exc
+
+        async def _stream() -> AsyncGenerator[VLMBatchChunk, None]:
+            try:
+                while True:
+                    item = await out_queue.get()
+                    if item is _STREAM_SENTINEL:
+                        return
+                    if isinstance(item, BaseException):
+                        raise item
+                    yield item
+            finally:
+                cancel_event.set()
+
+        return _stream()
+
+    def _run(self) -> None:
+        """Own the MLX stream, VLM embedding, and ``BatchGenerator`` loop."""
+        try:
+            new_thread_local_stream = getattr(mx, "new_thread_local_stream", None)
+            if new_thread_local_stream is not None:
+                self._stream = new_thread_local_stream(mx.default_device())
+            else:
+                self._stream = mx.new_stream(mx.default_device())
+            self._ready_event.set()
+        except BaseException as exc:  # noqa: BLE001 - surface to start()
+            self._start_error = exc
+            self._ready_event.set()
+            self._running = False
+            return
+
+        try:
+            while self._running:
+                self._admit_pending(block_if_empty=not self._active)
+                self._process_cancellations()
+
+                if not self._active or self._batch_generator is None:
+                    continue
+
+                self._step()
+                self._process_cancellations()
+        finally:
+            try:
+                if self._batch_generator is not None:
+                    self._batch_generator.close()
+            except Exception as exc:  # noqa: BLE001 - teardown best effort
+                logger.warning(f"Error closing VLM BatchGenerator: {exc!s}")
+            self._batch_generator = None
+            self._stream = None
+            self._fail_all_active(RuntimeError("VLMBatchScheduler stopped"))
+            self._drain_admission_queue(RuntimeError("VLMBatchScheduler stopped"))
+
+    def _admit_pending(self, *, block_if_empty: bool) -> None:
+        """Drain queued requests into ``BatchGenerator``."""
+        first_wait = block_if_empty
+        while True:
+            try:
+                if first_wait:
+                    request = self._admission_queue.get(timeout=self._idle_poll_timeout)
+                    first_wait = False
+                else:
+                    request = self._admission_queue.get_nowait()
+            except queue.Empty:
+                return
+
+            if request.cancel_event.is_set():
+                self._send(request.loop, request.out_queue, _STREAM_SENTINEL)
+                continue
+
+            if self._batch_generator is None:
+                self._batch_generator = self._create_batch_generator(request.sampler)
+
+            try:
+                input_ids, prompt_kwargs = self._build_prompt_kwargs(request.raw_inputs)
+                if prompt_kwargs.get("inputs_embeds") is not None and getattr(
+                    self._batch_generator, "unprocessed_prompts", None
+                ):
+                    self._flush_pending_prompts()
+
+                (uid,) = self._batch_generator.insert(
+                    [self._as_token_list(input_ids)],
+                    max_tokens=request.max_tokens,
+                    prompt_kwargs=[prompt_kwargs],
+                    logits_processors=(
+                        [request.logits_processors]
+                        if request.logits_processors is not None
+                        else None
+                    ),
+                )
+            except Exception as exc:  # noqa: BLE001 - report per request
+                self._fail_request(request, exc)
+                continue
+
+            self._active[uid] = _ActiveVLMRequest(
+                loop=request.loop,
+                out_queue=request.out_queue,
+                cancel_event=request.cancel_event,
+                prompt_tokens=request.prompt_tokens,
+                tokens=[],
+            )
+            logger.info(
+                f"VLMBatchScheduler admitted uid={uid} "
+                f"(active={len(self._active)}, prompt_tokens={request.prompt_tokens})"
+            )
+
+            # VLM/image requests need their prefill started immediately so
+            # their embedding kwargs do not get mixed with later text-only work.
+            self._step()
+
+    def _create_batch_generator(
+        self,
+        sampler: Callable[[mx.array], mx.array] | None,
+    ) -> Any:
+        """Create an ``mlx-vlm`` batch generator on the scheduler thread."""
+        return BatchGenerator(
+            self._language_model,
+            self._processor,
+            stop_tokens=self._stop_tokens,
+            sampler=sampler,
+            completion_batch_size=self._completion_batch_size,
+            prefill_batch_size=self._prefill_batch_size,
+            prefill_step_size=self._prefill_step_size,
+            kv_bits=self._kv_bits,
+            kv_group_size=self._kv_group_size,
+            kv_quant_scheme=self._kv_quant_scheme,
+            quantized_kv_start=self._quantized_kv_start,
+            stream=self._stream,
+        )
+
+    def _build_prompt_kwargs(self, raw_inputs: dict[str, Any]) -> tuple[Any, dict[str, Any]]:
+        """Run VLM embedding on the scheduler thread and return prompt kwargs."""
+        input_ids = raw_inputs.get("input_ids")
+        pixel_values = raw_inputs.get("pixel_values")
+        mask = raw_inputs.get("attention_mask")
+        if mask is None:
+            mask = raw_inputs.get("mask")
+        data_kwargs = {
+            key: value
+            for key, value in raw_inputs.items()
+            if key not in {"input_ids", "pixel_values", "attention_mask", "mask"}
+        }
+
+        embedding_output = self._model.get_input_embeddings(
+            input_ids,
+            pixel_values,
+            mask=mask,
+            **data_kwargs,
+        )
+        return input_ids, {**data_kwargs, **embedding_output.to_dict()}
+
+    @staticmethod
+    def _as_token_list(input_ids: Any) -> list[int]:
+        """Convert a 1-row token tensor/array/list into a plain token list."""
+        if hasattr(input_ids, "squeeze"):
+            input_ids = input_ids.squeeze(0)
+        if hasattr(input_ids, "tolist"):
+            input_ids = input_ids.tolist()
+        if input_ids and isinstance(input_ids[0], list):
+            input_ids = input_ids[0]
+        return [int(token) for token in input_ids]
+
+    def _step(self) -> None:
+        """Run one VLM batch step and forward responses."""
+        try:
+            _, responses = self._batch_generator.next()
+        except Exception as exc:  # noqa: BLE001 - propagate to active requests
+            logger.exception(f"VLM BatchGenerator.next() raised: {exc!s}")
+            self._fail_all_active(exc)
+            return
+
+        for response in responses:
+            self._handle_generation_response(response)
+
+    def _flush_pending_prompts(self) -> None:
+        """Drain queued prompt prefill work before inserting another image prompt."""
+        while getattr(self._batch_generator, "has_pending_prompts", False):
+            self._step()
+
+    def _handle_generation_response(self, response: Any) -> None:
+        """Forward one ``BatchGenerator`` response to its request queue."""
+        state = self._active.get(response.uid)
+        if state is None or state.cancel_event.is_set():
+            return
+
+        if state.first_token_time is None:
+            state.first_token_time = time.perf_counter()
+
+        token = response.token.item() if hasattr(response.token, "item") else response.token
+        finish_reason = response.finish_reason
+        state.tokens.append(int(token))
+
+        if finish_reason == "stop":
+            text = ""
+        else:
+            current_text = self._tokenizer.decode(state.tokens)
+            text = current_text[len(state.previous_text) :]
+            state.previous_text = current_text
+
+        generation_tokens = len(state.tokens)
+        is_final = finish_reason is not None
+        stats = self._batch_generator.stats() if is_final else None
+        chunk = VLMBatchChunk(
+            text=text,
+            token=int(token),
+            finish_reason=finish_reason,
+            generation_tokens=generation_tokens,
+            generation_tps=self._compute_tps(state) if is_final else 0.0,
+            prompt_tokens=state.prompt_tokens,
+            prompt_tps=getattr(stats, "prompt_tps", 0.0) if stats is not None else 0.0,
+            peak_memory=mx.get_peak_memory() / 1e9 if is_final else 0.0,
+        )
+        self._send(state.loop, state.out_queue, chunk)
+
+        if is_final:
+            logger.info(
+                f"VLMBatchScheduler uid={response.uid} finished "
+                f"(finish_reason={finish_reason}, generated={generation_tokens})"
+            )
+            self._send(state.loop, state.out_queue, _STREAM_SENTINEL)
+            self._active.pop(response.uid, None)
+
+    def _process_cancellations(self) -> None:
+        """Remove cancelled sequences from ``BatchGenerator``."""
+        cancelled_uids = [uid for uid, state in self._active.items() if state.cancel_event.is_set()]
+        if not cancelled_uids or self._batch_generator is None:
+            return
+        for uid in cancelled_uids:
+            try:
+                self._batch_generator.remove(uid)
+            except Exception as exc:  # noqa: BLE001 - cancellation is best effort
+                logger.warning(f"VLM BatchGenerator.remove failed for uid={uid}: {exc!s}")
+            state = self._active.pop(uid, None)
+            if state is not None:
+                chunk = VLMBatchChunk(
+                    text="",
+                    token=0,
+                    finish_reason="cancelled",
+                    generation_tokens=len(state.tokens),
+                    generation_tps=self._compute_tps(state),
+                    prompt_tokens=state.prompt_tokens,
+                    peak_memory=mx.get_peak_memory() / 1e9,
+                )
+                self._send(state.loop, state.out_queue, chunk)
+                self._send(state.loop, state.out_queue, _STREAM_SENTINEL)
+
+    def _resolve_stop_tokens(self) -> set[int]:
+        """Collect EOS token ids from model config."""
+        stop_tokens: set[int] = set()
+        eos_token_id = getattr(getattr(self._model, "config", None), "eos_token_id", None)
+        if isinstance(eos_token_id, list):
+            stop_tokens.update(int(token) for token in eos_token_id)
+        elif eos_token_id is not None:
+            stop_tokens.add(int(eos_token_id))
+        return stop_tokens
+
+    def get_stats(self) -> dict[str, Any]:
+        """Current scheduler queue and active-request stats."""
+        return {
+            "running": self._running,
+            "queue_size": self._admission_queue.qsize(),
+            "max_queue_size": self._queue_size,
+            "active_requests": len(self._active),
+        }
+
+    @staticmethod
+    def _compute_tps(state: _ActiveVLMRequest) -> float:
+        if state.first_token_time is None or not state.tokens:
+            return 0.0
+        elapsed = time.perf_counter() - state.first_token_time
+        if elapsed <= 0:
+            return 0.0
+        return len(state.tokens) / elapsed
+
+    def _fail_all_active(self, exc: BaseException) -> None:
+        for uid, state in list(self._active.items()):
+            self._send(state.loop, state.out_queue, exc)
+            self._send(state.loop, state.out_queue, _STREAM_SENTINEL)
+            self._active.pop(uid, None)
+
+    def _drain_admission_queue(self, exc: BaseException) -> None:
+        while True:
+            try:
+                request = self._admission_queue.get_nowait()
+            except queue.Empty:
+                return
+            self._fail_request(request, exc)
+
+    def _fail_request(self, request: _PendingVLMRequest, exc: BaseException) -> None:
+        self._send(request.loop, request.out_queue, exc)
+        self._send(request.loop, request.out_queue, _STREAM_SENTINEL)
+
+    @staticmethod
+    def _send(loop: asyncio.AbstractEventLoop, out_queue: asyncio.Queue[Any], item: Any) -> None:
+        """Thread-safe put of ``item`` onto an asyncio queue."""
+        try:
+            loop.call_soon_threadsafe(out_queue.put_nowait, item)
+        except RuntimeError:
+            logger.debug("Event loop closed before VLM scheduler response could be delivered")

--- a/app/handler/mlx_vlm.py
+++ b/app/handler/mlx_vlm.py
@@ -933,6 +933,14 @@ class MLXVLMHandler:
                     tool_choice = tool_choice.model_dump()
                 chat_template_kwargs["tool_choice"] = tool_choice
 
+        seed = request.seed
+        if self._is_request_batchable(request) and seed is not None and seed > 0:
+            logger.warning(
+                "Ignoring per-request seed because continuous batching is enabled; "
+                "start the server with --disable-batching to use request seeds."
+            )
+            seed = 0
+
         request_dict: dict[str, Any] = {
             "messages": chat_messages,
             "images": images,
@@ -944,7 +952,7 @@ class MLXVLMHandler:
             "top_p": request.top_p,
             "max_tokens": request.max_tokens,
             "max_completion_tokens": request.max_completion_tokens,
-            "seed": request.seed,
+            "seed": seed,
             "repetition_penalty": request.repetition_penalty,
             "repetition_context_size": request.repetition_context_size,
         }

--- a/app/handler/mlx_vlm.py
+++ b/app/handler/mlx_vlm.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 from loguru import logger
 
 from ..core import AudioProcessor, ImageProcessor, InferenceWorker, VideoProcessor
+from ..core.vlm_batch_scheduler import VLM_BATCHING_AVAILABLE, VLMBatchScheduler
 from ..message_converters import MessageConverterManager
 from ..models.mlx_vlm import MLX_VLM
 from ..parsers import ParserManager, ReasoningParserState, ToolParserState
@@ -56,6 +57,10 @@ class MLXVLMHandler:
         kv_bits: int | None = None,
         kv_group_size: int = 64,
         quantized_kv_start: int = 0,
+        batch_completion_size: int = 32,
+        batch_prefill_size: int = 8,
+        batch_prefill_step_size: int = 2048,
+        disable_batching: bool = False,
     ):
         """
         Initialize the handler with the specified model path.
@@ -73,6 +78,10 @@ class MLXVLMHandler:
             kv_bits (int | None): Number of bits for KV cache quantization. None disables quantization.
             kv_group_size (int): Group size for KV cache quantization. Default is 64.
             quantized_kv_start (int): Step to begin using a quantized KV cache. Default is 0.
+            batch_completion_size (int): Maximum concurrent VLM decode sequences.
+            batch_prefill_size (int): Maximum VLM prompts to prefill together.
+            batch_prefill_step_size (int): Maximum tokens per VLM prefill step.
+            disable_batching (bool): Disable VLM continuous batching.
         """
         self.model_path = model_path
         self.model = MLX_VLM(
@@ -108,6 +117,14 @@ class MLXVLMHandler:
         # Dedicated inference thread — keeps the event loop free during
         # blocking MLX model computation.
         self.inference_worker = InferenceWorker()
+        self._queue_size = 100
+        self._queue_timeout = 300.0
+        self._batch_completion_size = batch_completion_size
+        self._batch_prefill_size = batch_prefill_size
+        self._batch_prefill_step_size = batch_prefill_step_size
+        self._disable_batching = disable_batching
+        self._batch_scheduler: VLMBatchScheduler | None = None
+        self._batch_scheduler_lock = asyncio.Lock()
 
         logger.info(f"Initialized MLXHandler with model path: {model_path}")
         if disable_auto_resize:
@@ -144,12 +161,92 @@ class MLXVLMHandler:
                 "timeout": 300,
                 "queue_size": 100,
             }
+        self._queue_size = int(queue_config.get("queue_size", 100))
+        self._queue_timeout = float(queue_config.get("timeout", 300))
         self.inference_worker = InferenceWorker(
-            queue_size=queue_config.get("queue_size", 100),
-            timeout=queue_config.get("timeout", 300),
+            queue_size=self._queue_size,
+            timeout=self._queue_timeout,
         )
         self.inference_worker.start()
         logger.info("Initialized MLXVLMHandler and started inference worker")
+
+    def _is_request_batchable(self, request: ChatCompletionRequest) -> bool:
+        """Return whether a request should use VLM continuous batching."""
+        if self._disable_batching:
+            return False
+        if not VLM_BATCHING_AVAILABLE:
+            return False
+        return True
+
+    async def _get_or_start_scheduler(self) -> VLMBatchScheduler:
+        """Lazily construct and start the VLM batch scheduler."""
+        if self._batch_scheduler is not None and self._batch_scheduler.is_running:
+            return self._batch_scheduler
+        async with self._batch_scheduler_lock:
+            if self._batch_scheduler is None or not self._batch_scheduler.is_running:
+                scheduler = VLMBatchScheduler(
+                    self.model.model,
+                    self.model.processor,
+                    completion_batch_size=self._batch_completion_size,
+                    prefill_batch_size=self._batch_prefill_size,
+                    prefill_step_size=self._batch_prefill_step_size,
+                    kv_bits=self.kv_bits,
+                    kv_group_size=self.kv_group_size,
+                    quantized_kv_start=self.quantized_kv_start,
+                    queue_size=self._queue_size,
+                )
+                scheduler.start()
+                self._batch_scheduler = scheduler
+        return self._batch_scheduler
+
+    def _submit_batched_stream(
+        self,
+        scheduler: VLMBatchScheduler,
+        model_params: dict[str, Any],
+    ):
+        """Submit a multimodal request to the VLM scheduler."""
+        model_inputs = dict(model_params.get("model_inputs") or {})
+        return scheduler.submit_stream(
+            model_inputs,
+            prompt_tokens=self.model.count_prompt_tokens(model_inputs),
+            max_tokens=self.model.resolve_max_tokens(model_params),
+            sampler=self.model.build_sampler(model_params),
+            logits_processors=self.model.build_logits_processors(model_params) or None,
+        )
+
+    async def _collect_batched_response(
+        self,
+        scheduler: VLMBatchScheduler,
+        model_params: dict[str, Any],
+    ):
+        """Drain a VLM batched stream into a completion response object."""
+        from ..models.mlx_vlm import CompletionResponse
+
+        stream = self._submit_batched_stream(scheduler, model_params)
+        text_parts: list[str] = []
+        tokens: list[int] = []
+        final_chunk = None
+        async for chunk in stream:
+            if chunk.text:
+                text_parts.append(chunk.text)
+            tokens.append(chunk.token)
+            if chunk.finish_reason is not None:
+                final_chunk = chunk
+                break
+
+        return CompletionResponse(
+            text="".join(text_parts),
+            tokens=tokens,
+            peak_memory=final_chunk.peak_memory if final_chunk else 0.0,
+            generation_tps=final_chunk.generation_tps if final_chunk else 0.0,
+            prompt_tps=final_chunk.prompt_tps if final_chunk else 0.0,
+            prompt_tokens=(
+                final_chunk.prompt_tokens
+                if final_chunk
+                else self.model.count_prompt_tokens(model_params.get("model_inputs") or {})
+            ),
+            generation_tokens=final_chunk.generation_tokens if final_chunk else len(tokens),
+        )
 
     async def _build_inference_context(
         self, request: ChatCompletionRequest
@@ -228,13 +325,17 @@ class MLXVLMHandler:
                     {"prompt": input_prompt, "stream": True, **model_params},
                 )
 
-            response_generator = self.inference_worker.submit_stream(
-                self.model,
-                prompt=input_prompt,
-                stream=True,
-                verbose=self.debug,
-                **model_params,
-            )
+            if self._is_request_batchable(request):
+                scheduler = await self._get_or_start_scheduler()
+                response_generator = self._submit_batched_stream(scheduler, model_params)
+            else:
+                response_generator = self.inference_worker.submit_stream(
+                    self.model,
+                    prompt=input_prompt,
+                    stream=True,
+                    verbose=self.debug,
+                    **model_params,
+                )
 
             after_reasoning_close_content = None
             final_chunk = None
@@ -495,13 +596,17 @@ class MLXVLMHandler:
                     {"prompt": input_prompt, "stream": False, **model_params},
                 )
 
-            response = await self.inference_worker.submit(
-                self.model,
-                prompt=input_prompt,
-                stream=False,
-                verbose=self.debug,
-                **model_params,
-            )
+            if self._is_request_batchable(request):
+                scheduler = await self._get_or_start_scheduler()
+                response = await self._collect_batched_response(scheduler, model_params)
+            else:
+                response = await self.inference_worker.submit(
+                    self.model,
+                    prompt=input_prompt,
+                    stream=False,
+                    verbose=self.debug,
+                    **model_params,
+                )
 
             parsed_response = {"reasoning_content": None, "tool_calls": None, "content": None}
             response_text = response.text
@@ -618,6 +723,9 @@ class MLXVLMHandler:
 
     async def close(self):
         """Explicitly cleanup resources asynchronously."""
+        if self._batch_scheduler is not None:
+            self._batch_scheduler.stop()
+            self._batch_scheduler = None
         if hasattr(self, "image_processor"):
             await self.image_processor.cleanup()
         if hasattr(self, "audio_processor"):
@@ -633,6 +741,9 @@ class MLXVLMHandler:
         """
         try:
             logger.info("Cleaning up MLXVLMHandler resources")
+            if self._batch_scheduler is not None:
+                self._batch_scheduler.stop()
+                self._batch_scheduler = None
             if hasattr(self, "inference_worker"):
                 self.inference_worker.stop()
             if hasattr(self, "image_processor"):
@@ -659,6 +770,21 @@ class MLXVLMHandler:
         """
         return {
             "queue_stats": self.inference_worker.get_stats(),
+            "batch_stats": {
+                **(
+                    self._batch_scheduler.get_stats()
+                    if self._batch_scheduler is not None and self._batch_scheduler.is_running
+                    else {
+                        "running": False,
+                        "queue_size": 0,
+                        "max_queue_size": self._queue_size,
+                        "active_requests": 0,
+                    }
+                ),
+                "completion_batch_size": self._batch_completion_size,
+                "prefill_batch_size": self._batch_prefill_size,
+                "disabled": self._disable_batching,
+            },
         }
 
     async def _reformat_multimodal_content_part(

--- a/app/models/mlx_vlm.py
+++ b/app/models/mlx_vlm.py
@@ -142,6 +142,108 @@ class MLX_VLM:
                 inputs[key] = mx.array(value)
         return inputs
 
+    def count_prompt_tokens(self, model_inputs: dict[str, Any]) -> int:
+        """Return the number of text prompt tokens in prepared model inputs.
+
+        Parameters
+        ----------
+        model_inputs : dict[str, Any]
+            Prepared multimodal model inputs containing ``input_ids``.
+
+        Returns
+        -------
+        int
+            Number of prompt tokens in the first request row.
+        """
+        input_ids = model_inputs.get("input_ids")
+        if input_ids is None:
+            return 0
+        shape = getattr(input_ids, "shape", None)
+        if shape is not None:
+            return int(shape[-1])
+        if hasattr(input_ids, "size"):
+            return int(input_ids.size)
+        if input_ids and isinstance(input_ids[0], list):
+            return len(input_ids[0])
+        return len(input_ids)
+
+    def resolve_max_tokens(self, params: dict[str, Any]) -> int:
+        """Resolve the effective max generation token count.
+
+        Parameters
+        ----------
+        params : dict[str, Any]
+            Request generation parameters.
+
+        Returns
+        -------
+        int
+            Effective max token budget for generation.
+        """
+        max_tokens = params.get("max_tokens")
+        if max_tokens is None:
+            max_tokens = params.get("max_completion_tokens")
+        if max_tokens is None:
+            max_tokens = DEFAULT_MAX_TOKENS
+        return int(max_tokens)
+
+    def build_sampler(self, params: dict[str, Any]):
+        """Build a sampler compatible with ``mlx_vlm.generate.BatchGenerator``.
+
+        Parameters
+        ----------
+        params : dict[str, Any]
+            Request generation parameters.
+
+        Returns
+        -------
+        Callable | None
+            ``None`` for greedy sampling, otherwise a callable that samples
+            from log probabilities.
+        """
+        temperature = params.get("temperature")
+        if temperature is None:
+            temperature = DEFAULT_TEMPERATURE
+        if temperature == 0:
+            return None
+
+        top_p = params.get("top_p")
+        if top_p is None:
+            top_p = DEFAULT_TOP_P
+
+        def sampler(logprobs: mx.array) -> mx.array:
+            if 0 < top_p < 1.0:
+                from mlx_vlm.sample_utils import top_p_sampling
+
+                return top_p_sampling(logprobs, top_p, temperature)
+            return mx.random.categorical(logprobs * (1 / temperature))
+
+        return sampler
+
+    def build_logits_processors(self, params: dict[str, Any]) -> list[Any]:
+        """Build logits processors for structured multimodal generation.
+
+        Parameters
+        ----------
+        params : dict[str, Any]
+            Request generation parameters.
+
+        Returns
+        -------
+        list[Any]
+            Logits processors to apply during generation.
+        """
+        json_schema = params.get("schema")
+        if not json_schema:
+            return []
+        return [
+            JSONLogitsProcessor(
+                schema=json_schema,
+                tokenizer=self.outlines_tokenizer,
+                tensor_library_name="mlx",
+            )
+        ]
+
     def create_model_inputs(
         self,
         text: str,

--- a/app/models/mlx_vlm.py
+++ b/app/models/mlx_vlm.py
@@ -5,8 +5,7 @@ from typing import Any
 
 import mlx.core as mx
 from mlx_vlm import load, stream_generate
-from mlx_vlm.utils import process_inputs_with_fallback
-from mlx_vlm.video_generate import process_vision_info
+from mlx_vlm.utils import load_image, process_inputs_with_fallback
 from outlines.processors import JSONLogitsProcessor
 import torch
 
@@ -251,7 +250,7 @@ class MLX_VLM:
         audios: list[str] | None = None,
     ) -> dict[str, Any]:
         """Create MLX-ready multimodal inputs from formatted chat messages."""
-        image_inputs, video_inputs = process_vision_info(messages)
+        image_inputs, video_inputs = self._extract_vision_inputs(messages)
         inputs = self._create_processor_inputs(
             text,
             images=image_inputs,
@@ -259,6 +258,48 @@ class MLX_VLM:
             audios=audios or None,
         )
         return self._to_mlx_inputs(inputs)
+
+    def _extract_vision_inputs(
+        self, messages: list[dict[str, Any]]
+    ) -> tuple[list[Any] | None, Any]:
+        """Extract image/video inputs without loading video dependencies eagerly.
+
+        Parameters
+        ----------
+        messages : list[dict[str, Any]]
+            Chat-template messages containing already processed media paths.
+
+        Returns
+        -------
+        tuple[list[Any] | None, Any]
+            Image inputs and video inputs suitable for ``process_inputs_with_fallback``.
+        """
+        has_video = any(
+            isinstance(message.get("content"), list)
+            and any(
+                isinstance(part, dict) and (part.get("type") == "video" or "video" in part)
+                for part in message["content"]
+            )
+            for message in messages
+        )
+        if has_video:
+            from mlx_vlm.video_generate import process_vision_info
+
+            return process_vision_info(messages)
+
+        image_inputs: list[Any] = []
+        for message in messages:
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                image_source = part.get("image") or part.get("image_url")
+                if image_source is None:
+                    continue
+                image_inputs.append(load_image(image_source))
+        return (image_inputs or None), None
 
     def create_inputs(
         self,
@@ -364,6 +405,8 @@ class MLX_VLM:
 
 
 if __name__ == "__main__":
+    from mlx_vlm.video_generate import process_vision_info
+
     image_path = "examples/images/attention.png"
     video_path = "examples/videos/demo.mp4"
     model_path = "mlx-community/Qwen3-VL-2B-Thinking-8bit"

--- a/app/server.py
+++ b/app/server.py
@@ -266,6 +266,10 @@ def create_handler_from_config(model_cfg: ModelEntryConfig) -> Any:
                 kv_bits=model_cfg.kv_bits,
                 kv_group_size=model_cfg.kv_group_size,
                 quantized_kv_start=model_cfg.quantized_kv_start,
+                batch_completion_size=model_cfg.batch_completion_size,
+                batch_prefill_size=model_cfg.batch_prefill_size,
+                batch_prefill_step_size=model_cfg.batch_prefill_step_size,
+                disable_batching=model_cfg.disable_batching,
             ),
             model_cfg,
         )

--- a/tests/test_multimodal_audio_inputs.py
+++ b/tests/test_multimodal_audio_inputs.py
@@ -35,6 +35,7 @@ def _load_mlx_vlm_model_module(monkeypatch: pytest.MonkeyPatch) -> Any:
         }
 
     fake_utils_module.process_inputs_with_fallback = fake_process_inputs_with_fallback
+    fake_utils_module.load_image = lambda source: source
 
     fake_video_module = types.ModuleType("mlx_vlm.video_generate")
 

--- a/tests/test_vlm_batch_scheduler.py
+++ b/tests/test_vlm_batch_scheduler.py
@@ -1,0 +1,256 @@
+"""Unit tests for :class:`app.core.vlm_batch_scheduler.VLMBatchScheduler`."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+import sys
+import types
+from typing import Any
+
+import pytest
+
+
+@contextmanager
+def _fake_stream_cm(_stream: Any):
+    yield
+
+
+def _fake_device(_device: Any = None) -> object:
+    """Return a placeholder MLX device object for scheduler tests."""
+    return object()
+
+
+def _zero() -> int:
+    """Return zero for fake memory counters."""
+    return 0
+
+
+@dataclass
+class _FakeResponse:
+    """Small response object matching the fields used by the scheduler."""
+
+    uid: int
+    token: int
+    finish_reason: str | None = None
+
+
+@dataclass
+class _FakeScript:
+    """Pre-programmed output for one fake sequence."""
+
+    tokens: list[int]
+    finish_reason: str = "length"
+
+
+class _FakeStats:
+    """Fake batch statistics."""
+
+    prompt_tps = 123.0
+
+
+class FakeVLMBatchGenerator:
+    """In-memory stand-in for ``mlx_vlm.generate.BatchGenerator``."""
+
+    script_queue: list[_FakeScript] = []
+    init_kwargs: dict[str, Any] | None = None
+
+    def __init__(self, model: Any, processor: Any, **kwargs: Any) -> None:
+        self.model = model
+        self.processor = processor
+        self.__class__.init_kwargs = kwargs
+        self._uid = 0
+        self._pending: list[tuple[int, _FakeScript, int]] = []
+        self._unprocessed_sequences: list[Any] = []
+        self.removed: list[int] = []
+        self.closed = False
+
+    def insert(
+        self,
+        prompts: list[list[int]],
+        max_tokens: int | list[int] | None = None,
+        prompt_kwargs: list[dict[str, Any]] | None = None,
+        logits_processors: list[Any] | None = None,
+    ) -> list[int]:
+        uids: list[int] = []
+        for _prompt in prompts:
+            script = (
+                self.script_queue.pop(0)
+                if self.script_queue
+                else _FakeScript(tokens=[0], finish_reason="length")
+            )
+            uid = self._uid
+            self._uid += 1
+            self._pending.append((uid, script, 0))
+            uids.append(uid)
+        return uids
+
+    def next(self) -> tuple[list[Any], list[Any]]:
+        responses: list[Any] = []
+        pending: list[tuple[int, _FakeScript, int]] = []
+        for uid, script, index in self._pending:
+            is_last = index == len(script.tokens) - 1
+            responses.append(
+                _FakeResponse(
+                    uid=uid,
+                    token=script.tokens[index],
+                    finish_reason=script.finish_reason if is_last else None,
+                )
+            )
+            if not is_last:
+                pending.append((uid, script, index + 1))
+        self._pending = pending
+        return [], responses
+
+    def remove(self, uid: int) -> bool:
+        self.removed.append(uid)
+        self._pending = [item for item in self._pending if item[0] != uid]
+        return True
+
+    @property
+    def unprocessed_prompts(self) -> list[Any]:
+        return self._unprocessed_sequences
+
+    @property
+    def has_pending_prompts(self) -> bool:
+        return bool(self._unprocessed_sequences)
+
+    def stats(self) -> _FakeStats:
+        return _FakeStats()
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeTokenizer:
+    """Minimal tokenizer surface used by the scheduler."""
+
+    def decode(self, tokens: list[int]) -> str:
+        """Decode fake token ids into visible text."""
+        return "".join(f"<{token}>" for token in tokens)
+
+
+class FakeProcessor:
+    """Minimal processor with a tokenizer."""
+
+    tokenizer = FakeTokenizer()
+
+
+class _FakeEmbeddingOutput:
+    """Fake embedding result returned by ``get_input_embeddings``."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return fake embedding kwargs."""
+        return {"inputs_embeds": [[1, 2, 3]]}
+
+
+class FakeModel:
+    """Minimal VLM wrapper model used by tests."""
+
+    language_model = object()
+
+    def get_input_embeddings(self, *args: Any, **kwargs: Any) -> _FakeEmbeddingOutput:
+        """Return fake embeddings for the scheduler to pass to BatchGenerator."""
+        return _FakeEmbeddingOutput()
+
+
+@pytest.fixture
+def patched_vlm_scheduler(monkeypatch):
+    """Patch MLX stream calls and VLM BatchGenerator."""
+    from app.core import vlm_batch_scheduler as module
+
+    monkeypatch.setattr(module, "BatchGenerator", FakeVLMBatchGenerator)
+    monkeypatch.setattr(module.mx, "stream", _fake_stream_cm)
+    monkeypatch.setattr(module.mx, "new_stream", _fake_device)
+    monkeypatch.setattr(module.mx, "new_thread_local_stream", _fake_device, raising=False)
+    monkeypatch.setattr(module.mx, "default_device", _fake_device)
+    monkeypatch.setattr(module.mx, "get_peak_memory", _zero)
+    FakeVLMBatchGenerator.script_queue = []
+    FakeVLMBatchGenerator.init_kwargs = None
+    return module
+
+
+@pytest.mark.asyncio
+async def test_vlm_scheduler_streams_chunks(patched_vlm_scheduler):
+    """The VLM scheduler should stream per-request chunks and final stats."""
+    FakeVLMBatchGenerator.script_queue = [_FakeScript(tokens=[11, 12])]
+    scheduler = patched_vlm_scheduler.VLMBatchScheduler(
+        FakeModel(),
+        FakeProcessor(),
+        completion_batch_size=4,
+        prefill_batch_size=1,
+        prefill_step_size=16,
+        kv_bits=4,
+        queue_size=10,
+    )
+    scheduler.start()
+    try:
+        stream = scheduler.submit_stream(
+            {"input_ids": [[1, 2, 3]], "pixel_values": "image"},
+            prompt_tokens=3,
+            max_tokens=2,
+        )
+        chunks = [chunk async for chunk in stream]
+    finally:
+        scheduler.stop()
+
+    assert [chunk.text for chunk in chunks] == ["<11>", "<12>"]
+    assert chunks[-1].finish_reason == "length"
+    assert chunks[-1].prompt_tokens == 3
+    assert chunks[-1].generation_tokens == 2
+    assert FakeVLMBatchGenerator.init_kwargs["completion_batch_size"] == 4
+    assert FakeVLMBatchGenerator.init_kwargs["prefill_batch_size"] == 1
+    assert FakeVLMBatchGenerator.init_kwargs["prefill_step_size"] == 16
+    assert FakeVLMBatchGenerator.init_kwargs["kv_bits"] == 4
+
+
+def test_vlm_handler_batchability_flag(monkeypatch):
+    """``--disable-batching`` should route VLM requests to the worker path."""
+    fake_mlx_vlm_module = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm_module.load = lambda *args, **kwargs: (None, None)
+    fake_mlx_vlm_module.stream_generate = lambda *args, **kwargs: iter(())
+    fake_sample_utils = types.ModuleType("mlx_vlm.sample_utils")
+    fake_sample_utils.top_p_sampling = lambda logprobs, *_args: logprobs
+    fake_utils = types.ModuleType("mlx_vlm.utils")
+    fake_utils.process_inputs_with_fallback = lambda *args, **kwargs: {}
+    fake_video = types.ModuleType("mlx_vlm.video_generate")
+    fake_video.process_vision_info = lambda _messages: ([], [])
+    fake_outlines = types.ModuleType("outlines")
+    fake_processors = types.ModuleType("outlines.processors")
+
+    class _FakeJSONLogitsProcessor:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    fake_processors.JSONLogitsProcessor = _FakeJSONLogitsProcessor
+    fake_outlines_tokenizer = types.ModuleType("app.utils.outlines_transformer_tokenizer")
+
+    class _FakeOutlinesTransformerTokenizer:
+        def __init__(self, tokenizer: Any) -> None:
+            self.tokenizer = tokenizer
+
+    fake_outlines_tokenizer.OutlinesTransformerTokenizer = _FakeOutlinesTransformerTokenizer
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm_module)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.sample_utils", fake_sample_utils)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.utils", fake_utils)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.video_generate", fake_video)
+    monkeypatch.setitem(sys.modules, "outlines", fake_outlines)
+    monkeypatch.setitem(sys.modules, "outlines.processors", fake_processors)
+    monkeypatch.setitem(
+        sys.modules,
+        "app.utils.outlines_transformer_tokenizer",
+        fake_outlines_tokenizer,
+    )
+    monkeypatch.delitem(sys.modules, "app.models.mlx_vlm", raising=False)
+    monkeypatch.delitem(sys.modules, "app.handler.mlx_vlm", raising=False)
+
+    from app.handler import mlx_vlm as module
+
+    handler = object.__new__(module.MLXVLMHandler)
+    handler._disable_batching = False
+    monkeypatch.setattr(module, "VLM_BATCHING_AVAILABLE", True)
+    assert handler._is_request_batchable(object()) is True
+
+    handler._disable_batching = True
+    assert handler._is_request_batchable(object()) is False

--- a/tests/test_vlm_batch_scheduler.py
+++ b/tests/test_vlm_batch_scheduler.py
@@ -213,6 +213,7 @@ def test_vlm_handler_batchability_flag(monkeypatch):
     fake_sample_utils.top_p_sampling = lambda logprobs, *_args: logprobs
     fake_utils = types.ModuleType("mlx_vlm.utils")
     fake_utils.process_inputs_with_fallback = lambda *args, **kwargs: {}
+    fake_utils.load_image = lambda source: source
     fake_video = types.ModuleType("mlx_vlm.video_generate")
     fake_video.process_vision_info = lambda _messages: ([], [])
     fake_outlines = types.ModuleType("outlines")


### PR DESCRIPTION
Add continuous batching support for mlx-vlm multimodal requests.

## Summary

- Add a VLM-specific continuous batch scheduler backed by `mlx_vlm.generate.BatchGenerator`.
- Route multimodal streaming and non-streaming chat completions through the VLM batcher when batching is enabled.
- Reuse existing launch/YAML batching controls (`--decode-concurrency`, `--prompt-concurrency`, `--prefill-step-size`, `--disable-batching`) for multimodal models.
- Keep VLM prompt-prefix caching intentionally unsupported; mlx-vlm prompt-cache support is still limited, so this focuses only on parallel request batching.
- Avoid importing `mlx_vlm.video_generate` during image/audio-only startup paths so `cv2` is loaded only when video inputs are actually used.
- Warn when a positive per-request seed is ignored on the VLM batched path, matching the LM batching policy.
- Update docs and tests for multimodal batching behavior.

## Motivation

The existing multimodal handler ran each mlx-vlm request through the single-request inference worker. That serialized concurrent requests and left mlx-vlm's upstream continuous batching support unused.

This change follows the same architecture used by mlx-vlm's server: CPU/media preprocessing happens before admission, while the scheduler thread owns MLX GPU work, builds VLM input embeddings, inserts requests into `BatchGenerator`, and steps generation continuously.

## Notes

Prompt-prefix caching is deliberately not added for VLM. The mlx-vlm prompt-cache surface is not mature enough for this server's thread-affinity requirements, and the user-facing goal here is parallel request handling through continuous batching.

The Objective-C duplicate class warnings from `av`/`cv2` were caused by importing mlx-vlm's video helper on startup. Image-only and audio-only requests no longer import that module; video requests still load it lazily when needed.

## Verification

```bash
./.venv/bin/python -m pytest tests/test_multimodal_audio_inputs.py tests/test_vlm_batch_scheduler.py tests/test_cli_sampling_defaults_parity.py tests/test_multi_model_per_model_defaults.py tests/test_chat_completions_defaults.py -q
./.venv/bin/ruff check app/core/vlm_batch_scheduler.py app/handler/mlx_vlm.py app/models/mlx_vlm.py app/server.py app/cli.py tests/test_vlm_batch_scheduler.py tests/test_multimodal_audio_inputs.py
./.venv/bin/ruff format app/core/vlm_batch_scheduler.py app/handler/mlx_vlm.py app/models/mlx_vlm.py app/server.py app/cli.py tests/test_vlm_batch_scheduler.py tests/test_multimodal_audio_inputs.py
```

Targeted tests passed locally. A real mlx-vlm GPU smoke test still needs to be run on an Apple Silicon environment with Metal access.