### PR TITLE
Fix/configurable startup timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ The request `model` should be the model path, `--served-model-name`, or YAML `se
 | `--served-model-name` | model path | Alias accepted in API requests |
 | `--host` | `0.0.0.0` | Bind host |
 | `--port` | `8000` | Bind port |
+| `--startup-timeout` | `1800` | Seconds without startup progress before model loading fails; active downloads/progress reset this timer |
 | `--context-length` | model default | LM and multimodal context/cache length |
 | `--max-tokens` | `100000` | Default generated tokens when request omits `max_tokens` |
 | `--temperature` | `1.0` | Default sampling temperature |
@@ -316,6 +317,8 @@ Important YAML keys:
 |-----|-------|
 | `model_path`, `model_type`, `served_model_name` | Model identity and routing |
 | `context_length` | LM/multimodal context length |
+| `startup_timeout` | Seconds without startup progress before model loading fails; active downloads/progress reset this timer |
+| `queue_timeout`, `queue_size` | Per-model request queue timeout and pending request capacity |
 | `prompt_cache_size`, `prompt_cache_max_bytes`, `prompt_cache_dir` | Prompt KV cache limits and disk location |
 | `batch_completion_size`, `batch_prefill_size`, `batch_prefill_step_size`, `disable_batching` | Continuous batching controls |
 | `kv_bits`, `kv_group_size`, `quantized_kv_start` | KV cache quantization |

--- a/app/cli.py
+++ b/app/cli.py
@@ -174,6 +174,12 @@ def cli():
 )
 @click.option("--port", default=8000, type=int, help="Port to run the server on")
 @click.option("--host", default="0.0.0.0", help="Host to run the server on")
+@click.option(
+    "--startup-timeout",
+    default=1800,
+    type=click.IntRange(min=1),
+    help="Seconds to wait for model loading before startup fails. Default is 1800.",
+)
 @click.option("--queue-timeout", default=300, type=int, help="Request timeout in seconds")
 @click.option("--queue-size", default=100, type=int, help="Maximum queue size for pending requests")
 @click.option(
@@ -403,6 +409,7 @@ def launch(
     served_model_name,
     port,
     host,
+    startup_timeout,
     queue_timeout,
     queue_size,
     quantize,
@@ -479,6 +486,7 @@ def launch(
         served_model_name=served_model_name,
         port=port,
         host=host,
+        startup_timeout=startup_timeout,
         queue_timeout=queue_timeout,
         queue_size=queue_size,
         quantize=quantize,

--- a/app/config.py
+++ b/app/config.py
@@ -37,6 +37,7 @@ class MLXServerConfig:
     served_model_name: str | None = None
     port: int = 8000
     host: str = "0.0.0.0"
+    startup_timeout: int = 1800
     queue_timeout: int = 300
     queue_size: int = 100
     disable_auto_resize: bool = False
@@ -180,6 +181,7 @@ class MLXServerConfig:
             model_type=self.model_type,
             served_model_name=self.served_model_name or self.model_path,
             context_length=self.context_length,
+            startup_timeout=self.startup_timeout,
             queue_timeout=self.queue_timeout,
             queue_size=self.queue_size,
             quantize=self.quantize,
@@ -267,6 +269,7 @@ class ModelEntryConfig:
 
     # Common options
     context_length: int | None = None
+    startup_timeout: int = 1800
     queue_timeout: int = 300
     queue_size: int = 100
 

--- a/app/core/handler_process.py
+++ b/app/core/handler_process.py
@@ -529,6 +529,7 @@ class HandlerProcessProxy:
 
         # RPC timeout for calls to the child process.
         self._rpc_timeout: float = 600.0
+        self._startup_timeout: float = 1800.0
 
         # Auto-restart state.
         self._queue_config: dict[str, Any] | None = None
@@ -551,10 +552,12 @@ class HandlerProcessProxy:
         Raises
         ------
         RuntimeError
-            If the child process fails to initialize within 300 s.
+            If the child process fails to initialize before the startup
+            idle timeout elapses.
         """
         self._loop = asyncio.get_running_loop()
         self._running = True
+        self._startup_timeout = float(queue_config.get("startup_timeout", 1800))
         self._rpc_timeout = float(queue_config.get("timeout", 300))
         self._queue_config = queue_config
 
@@ -589,7 +592,7 @@ class HandlerProcessProxy:
 
         try:
             try:
-                response = await self._wait_for_ready(ready_queue, timeout=300)
+                response = await self._wait_for_ready(ready_queue, timeout=self._startup_timeout)
             finally:
                 self._pending.pop("__ready__", None)
 
@@ -635,8 +638,8 @@ class HandlerProcessProxy:
         Raises
         ------
         RuntimeError
-            If the child dies or the timeout expires before a ready
-            signal is received.
+            If the child dies or no ready/progress signal is received
+            before the timeout expires.
         """
         deadline = time.monotonic() + timeout
         poll_interval = 2.0
@@ -646,7 +649,7 @@ class HandlerProcessProxy:
             if remaining <= 0:
                 raise RuntimeError(
                     f"Handler process for '{self.served_model_name}' "
-                    f"did not become ready within {timeout:.0f} s"
+                    f"did not become ready within {timeout:.0f} s without startup progress"
                 )
 
             try:
@@ -676,9 +679,9 @@ class HandlerProcessProxy:
                 else:
                     logger.debug(line)
                 # Reset the deadline on every progress message so a
-                # slow-but-steady download doesn't trip the timeout. A
-                # genuine hang (no progress, no crash) still fails after
-                # the normal window elapses.
+                # slow-but-steady download or load stage doesn't trip
+                # the timeout. A genuine hang (no progress, no crash)
+                # still fails after the normal window elapses.
                 deadline = time.monotonic() + timeout
                 continue
 
@@ -807,7 +810,7 @@ class HandlerProcessProxy:
         self._pending["__ready__"] = ready_queue
 
         try:
-            response = await self._wait_for_ready(ready_queue, timeout=300)
+            response = await self._wait_for_ready(ready_queue, timeout=self._startup_timeout)
         finally:
             self._pending.pop("__ready__", None)
 

--- a/app/main.py
+++ b/app/main.py
@@ -84,6 +84,7 @@ def print_startup_banner(config_args: MLXServerConfig) -> None:
         logger.info(f"🔮 Context Length: {config_args.context_length}")
     logger.info(f"🌐 Host: {config_args.host}")
     logger.info(f"🔌 Port: {config_args.port}")
+    logger.info(f"⏱️ Startup Timeout: {config_args.startup_timeout} seconds without progress")
     logger.info(f"⏱️ Queue Timeout: {config_args.queue_timeout} seconds")
     logger.info(f"📊 Queue Size: {config_args.queue_size}")
     if config_args.model_type in ["image-generation", "image-edit"]:
@@ -147,6 +148,8 @@ def _model_entry_extras(m: ModelEntryConfig) -> list[tuple[str, object]]:
         extras.append(("served_model_name", m.served_model_name))
     if m.context_length is not None:
         extras.append(("context_length", m.context_length))
+    if m.startup_timeout != _MODEL_ENTRY_DEFAULTS["startup_timeout"]:
+        extras.append(("startup_timeout", f"{m.startup_timeout}s without progress"))
     if m.enable_auto_tool_choice:
         extras.append(("auto_tool_choice", True))
     if m.tool_call_parser:

--- a/app/server.py
+++ b/app/server.py
@@ -180,6 +180,7 @@ def create_lifespan(config_args: MLXServerConfig):
             handler = create_handler_from_config(model_cfg)
             await handler.initialize(
                 {
+                    "startup_timeout": config_args.startup_timeout,
                     "timeout": config_args.queue_timeout,
                     "queue_size": config_args.queue_size,
                 }
@@ -407,6 +408,7 @@ def create_multi_lifespan(config: MultiModelServerConfig):
                 model_cfg_dict = asdict(model_cfg)
 
                 queue_config = {
+                    "startup_timeout": model_cfg.startup_timeout,
                     "timeout": model_cfg.queue_timeout,
                     "queue_size": model_cfg.queue_size,
                 }

--- a/tests/test_cli_sampling_defaults_parity.py
+++ b/tests/test_cli_sampling_defaults_parity.py
@@ -116,6 +116,35 @@ def test_launch_leaves_sampling_defaults_unset_when_flags_are_omitted(
     assert model_config.default_max_tokens is None
 
 
+def test_launch_accepts_startup_timeout_and_passes_it_to_wrapped_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI should expose ``--startup-timeout`` for subprocess model loading."""
+
+    cli_module = _load_cli_module(monkeypatch)
+    captured: dict[str, Any] = {}
+
+    async def _fake_start_multi(config: Any) -> None:
+        captured["config"] = config
+
+    monkeypatch.setattr(cli_module, "start_multi", _fake_start_multi)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "launch",
+            "--model-path",
+            "dummy-model",
+            "--startup-timeout",
+            "3600",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["config"].models[0].startup_timeout == 3600
+
+
 def test_start_exports_repetition_penalty_before_server_setup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_handler_process_startup_timeout.py
+++ b/tests/test_handler_process_startup_timeout.py
@@ -1,0 +1,86 @@
+"""Regression tests for handler subprocess startup timeout configuration."""
+
+from __future__ import annotations
+
+import queue
+from typing import Any
+
+import pytest
+
+from app.config import ModelEntryConfig
+from app.core.handler_process import HandlerProcessProxy
+
+
+class _FakeProcess:
+    """Minimal process stub used by ``HandlerProcessProxy.start``."""
+
+    pid: int = 12345
+    exitcode: int | None = None
+
+    def start(self) -> None:
+        """Pretend to start a subprocess."""
+
+    def is_alive(self) -> bool:
+        """Return True while startup is being tested."""
+
+        return True
+
+
+class _FakeSpawnContext:
+    """Minimal spawn context that avoids creating a real child process."""
+
+    def Queue(self) -> queue.Queue[dict[str, Any]]:
+        """Return an in-process queue compatible with the reader thread."""
+
+        return queue.Queue()
+
+    def Process(self, **_kwargs: Any) -> _FakeProcess:
+        """Return a fake process object."""
+
+        return _FakeProcess()
+
+
+@pytest.mark.asyncio
+async def test_start_uses_configured_startup_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Proxy startup should wait using ``startup_timeout``, not request timeout."""
+
+    model_cfg = ModelEntryConfig(
+        model_path="dummy-model",
+        model_type="lm",
+        served_model_name="dummy-model",
+        startup_timeout=3600,
+        queue_timeout=30,
+    )
+    proxy = HandlerProcessProxy(
+        model_cfg_dict=model_cfg.__dict__.copy(),
+        model_type=model_cfg.model_type,
+        model_path=model_cfg.model_path,
+        served_model_name=model_cfg.served_model_name,
+    )
+    proxy._ctx = _FakeSpawnContext()  # type: ignore[assignment]
+    observed_timeout: list[float] = []
+
+    async def _fake_wait_for_ready(
+        _ready_queue: queue.Queue[dict[str, Any]],
+        timeout: float = 300,
+    ) -> dict[str, Any]:
+        observed_timeout.append(timeout)
+        return {"type": "ready", "success": True}
+
+    monkeypatch.setattr(proxy, "_wait_for_ready", _fake_wait_for_ready)
+
+    try:
+        await proxy.start(
+            {
+                "startup_timeout": model_cfg.startup_timeout,
+                "timeout": model_cfg.queue_timeout,
+                "queue_size": model_cfg.queue_size,
+            }
+        )
+    finally:
+        proxy._running = False
+        if proxy._reader_thread is not None:
+            proxy._reader_thread.join(timeout=2)
+
+    assert observed_timeout == [3600.0]
+    assert proxy._rpc_timeout == 30.0

--- a/tests/test_multi_model_per_model_defaults.py
+++ b/tests/test_multi_model_per_model_defaults.py
@@ -226,6 +226,24 @@ def test_load_config_from_yaml_preserves_per_model_sampling_defaults(tmp_path: P
         assert getattr(config.models[1], key) == expected
 
 
+def test_load_config_from_yaml_preserves_startup_timeout(tmp_path: Path) -> None:
+    """Multi-model YAML should preserve per-model startup timeout overrides."""
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n"
+        "  - model_path: /models/model-a\n"
+        "    model_type: lm\n"
+        "    served_model_name: model-a\n"
+        "    startup_timeout: 3600\n",
+        encoding="utf-8",
+    )
+
+    config = load_config_from_yaml(str(config_path))
+
+    assert config.models[0].startup_timeout == 3600
+
+
 @pytest.mark.asyncio
 async def test_chat_completions_can_apply_different_defaults_per_model(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
fix: make handler startup timeout configurable

## Summary

- add a `--startup-timeout` CLI flag and `startup_timeout` YAML key for model startup readiness waits
- default startup readiness timeout to 1800 seconds instead of the previous hardcoded 300 seconds
- keep startup timeout separate from request `queue_timeout`
- continue resetting the startup deadline when the child process reports progress, so active downloads or load progress do not consume the timeout window
- document the new option and add regression coverage for CLI, YAML, and handler proxy plumbing

## Why

Large models, especially when downloaded or loaded from slow storage such as a NAS, can take longer than 300 seconds to become ready. Previously the parent process still used a hardcoded 300-second readiness wait even when request timeout settings were changed.

Fixes #293.

## Testing

- `./.venv/bin/ruff check app/config.py app/cli.py app/server.py app/main.py app/core/handler_process.py tests/test_cli_sampling_defaults_parity.py tests/test_multi_model_per_model_defaults.py tests/test_handler_process_startup_timeout.py`
- `./.venv/bin/python -m pytest tests/test_cli_sampling_defaults_parity.py tests/test_multi_model_per_model_defaults.py::test_load_config_from_yaml_preserves_startup_timeout tests/test_handler_process_startup_timeout.py`
- `./.venv/bin/pre-commit run --all-files`