### PR TITLE
fix: unify console/file logging and capture subprocess + startup logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/app/core/handler_process.py
+++ b/app/core/handler_process.py
@@ -256,7 +256,20 @@ def _handler_worker(
     import mlx.core as mx
 
     from app.config import ModelEntryConfig
-    from app.server import create_handler_from_config
+    from app.server import configure_logging, create_handler_from_config
+
+    # loguru configuration does not survive ``spawn`` — reconstruct the same
+    # sinks here so child logs (model load, inference, per-request errors)
+    # reach the configured log file and honour the requested log level
+    # instead of falling back to loguru's default stderr-only handler.
+    # Rotation is left to the parent to avoid multiple processes racing to
+    # rotate a shared file.
+    configure_logging(
+        log_file=queue_config.get("log_file"),
+        no_log_file=queue_config.get("no_log_file", False),
+        log_level=queue_config.get("log_level", "INFO"),
+        enable_rotation=False,
+    )
 
     # Remember the parent PID so the request loop can detect if the
     # parent dies unexpectedly (e.g. SIGKILL).  Because we use the

--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -1064,9 +1064,11 @@ class MLXLMHandler:
                 request_data["checkpoint_callback"] = ctx.checkpoint_callback
 
             if self.debug:
+                debug_request_data = self._with_effective_sampling_params(request_data)
+                log_debug_request(debug_request_data)
                 log_debug_model_dispatch(
                     "mlx_lm.generate_text_response.submit",
-                    self._with_effective_sampling_params(request_data),
+                    debug_request_data,
                 )
 
             response = await self._run_nonstream_generation(request, ctx, request_data)

--- a/app/main.py
+++ b/app/main.py
@@ -267,11 +267,12 @@ async def start(config: MLXServerConfig) -> None:
     """
     try:
         _apply_sampling_env(config)
+        # setup_server() configures logging (console + file sinks); build it
+        # before the banner so the startup banner is captured in the log file.
+        uvconfig = setup_server(config)
         # Display startup information
         print_startup_banner(config)
 
-        # Set up and start the server
-        uvconfig = setup_server(config)
         logger.info("Server configuration complete.")
         logger.info("Starting Uvicorn server...")
         server = uvicorn.Server(uvconfig)
@@ -295,9 +296,10 @@ async def start_multi(config: MultiModelServerConfig) -> None:
         Multi-model YAML-based configuration.
     """
     try:
-        print_multi_startup_banner(config)
-
+        # setup_server() configures logging (console + file sinks); build it
+        # before the banner so the banner is captured in the log file too.
         uvconfig = setup_server(config)
+        print_multi_startup_banner(config)
         logger.info("Multi-handler server configuration complete.")
         logger.info("Starting Uvicorn server...")
         server = uvicorn.Server(uvconfig)

--- a/app/server.py
+++ b/app/server.py
@@ -86,15 +86,41 @@ def _attach_sampling_defaults(handler: Any, config: Any) -> Any:
     return handler
 
 
+# Shared log format for both the console and file sinks. Color/markup tags
+# are rendered on the (colorized) console sink and automatically stripped by
+# loguru on the (non-colorized) file sink, so both carry the same fields —
+# crucially including ``name:function:line`` so the file is a faithful
+# transcript of the console rather than a stripped-down subset.
+_LOG_FORMAT = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
+    "<level>{level: <8}</level> | "
+    "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> | "
+    "✦ <level>{message}</level>"
+)
+
+
 def configure_logging(
-    log_file: str | None = None, no_log_file: bool = False, log_level: str = "INFO"
+    log_file: str | None = None,
+    no_log_file: bool = False,
+    log_level: str = "INFO",
+    *,
+    enable_rotation: bool = True,
 ) -> None:
     """Set up loguru handlers used by the server.
 
     This helper replaces the default loguru handler with a console
     handler using a compact, colored format. When ``no_log_file`` is
-    False a rotating file handler is also added using ``log_file`` or
-    a default path.
+    False a file handler is also added using ``log_file`` or a default
+    path, sharing the same format as the console (minus color) so the
+    file is a faithful transcript rather than a stripped-down subset.
+
+    Because each model handler runs in its own spawned subprocess and
+    loguru configuration does not survive ``spawn``, this function is
+    called both in the parent process and in every child process (see
+    ``app.core.handler_process._handler_worker``). All processes append
+    to the same ``log_file``, but only the parent owns rotation/retention
+    (``enable_rotation``) to avoid multiple processes racing to rotate
+    the same file.
 
     Parameters
     ----------
@@ -107,6 +133,10 @@ def configure_logging(
         emitted.
     log_level:
         Minimum log level to emit (e.g. "DEBUG", "INFO").
+    enable_rotation:
+        When True (the parent process) the file sink rotates at 500 MB
+        and retains 10 days of history. Child processes pass False so
+        they only ever append, leaving rotation to the parent.
     """
     logger.remove()  # Remove default handler
 
@@ -114,21 +144,22 @@ def configure_logging(
     logger.add(
         print,
         level=log_level,
-        format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
-        "<level>{level: <8}</level> | "
-        "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> | "
-        "✦ <level>{message}</level>",
+        format=_LOG_FORMAT,
         colorize=True,
     )
     if not no_log_file:
         file_path = log_file or "logs/app.log"
-        logger.add(
-            file_path,
-            rotation="500 MB",
-            retention="10 days",
-            level=log_level,
-            format="{time:YYYY-MM-DD HH:mm:ss} | {level} | {message}",
-        )
+        file_kwargs: dict[str, object] = {
+            "level": log_level,
+            "format": _LOG_FORMAT,
+            # Serialize writes within a process; combined with append-mode
+            # this keeps records intact when parent + children share a file.
+            "enqueue": True,
+        }
+        if enable_rotation:
+            file_kwargs["rotation"] = "500 MB"
+            file_kwargs["retention"] = "10 days"
+        logger.add(file_path, **file_kwargs)
 
 
 def create_lifespan(config_args: MLXServerConfig):
@@ -409,6 +440,11 @@ def create_multi_lifespan(config: MultiModelServerConfig):
                 queue_config = {
                     "timeout": model_cfg.queue_timeout,
                     "queue_size": model_cfg.queue_size,
+                    # Logging config so the spawned child can reconstruct the
+                    # same sinks (loguru state does not survive ``spawn``).
+                    "log_file": config.log_file,
+                    "no_log_file": config.no_log_file,
+                    "log_level": config.log_level,
                 }
 
                 if model_cfg.on_demand:

--- a/app/server.py
+++ b/app/server.py
@@ -140,9 +140,13 @@ def configure_logging(
     """
     logger.remove()  # Remove default handler
 
-    # Add console handler
+    # Add console handler. Use ``sys.stderr`` rather than ``print`` as the
+    # sink: loguru's formatted message already ends with a newline, so passing
+    # ``print`` (which appends its own newline) produced a blank line between
+    # every console record. A file-like sink is written via ``.write()`` and
+    # adds no extra newline, matching the file sink output.
     logger.add(
-        print,
+        sys.stderr,
         level=log_level,
         format=_LOG_FORMAT,
         colorize=True,

--- a/app/utils/debug_logging.py
+++ b/app/utils/debug_logging.py
@@ -216,11 +216,12 @@ def _summarize_for_debug(value: Any, max_depth: int = 2) -> Any:
         return {"type": "tuple", "len": len(value), "preview": preview_items}
 
     if isinstance(value, dict):
+        max_keys = 50
         summary: dict[str, Any] = {}
-        for key, item in list(value.items())[:20]:
+        for key, item in list(value.items())[:max_keys]:
             summary[str(key)] = _summarize_for_debug(item, max_depth - 1)
-        if len(value) > 20:
-            summary["..."] = f"+{len(value) - 20} more keys"
+        if len(value) > max_keys:
+            summary["..."] = f"+{len(value) - max_keys} more keys"
         return summary
 
     return f"<{type(value).__name__}>"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,272 @@
+# Configuration Reference
+
+This document is the complete, source-of-truth reference for configuring
+`mlx-openai-server`. It is generated from the actual definitions in
+[`app/cli.py`](../app/cli.py) (the Click options) and
+[`app/config.py`](../app/config.py) (the `MLXServerConfig`,
+`ModelEntryConfig`, and `MultiModelServerConfig` dataclasses). If you change
+those files, update this doc.
+
+---
+
+## The two configuration surfaces
+
+There are **two ways** to configure the server, and they are mutually
+exclusive:
+
+| Mode | How it's selected | Where settings come from |
+|------|-------------------|--------------------------|
+| **Single-model** | `--model-path` given, **no** `--config` | CLI flags only |
+| **Multi-handler** | `--config <file.yaml>` given | The YAML file only |
+
+> ### ⚠️ The most important gotcha
+>
+> **When `--config` is supplied, every other CLI flag is silently ignored** —
+> no warning, no error. This includes server-level flags you might expect to
+> still apply, such as `--port`, `--host`, `--log-level`, `--log-file`, and
+> `--queue-timeout`.
+>
+> In `--config` mode, *all* configuration must live in the YAML file. See
+> [`app/cli.py`](../app/cli.py): the `if config_file is not None:` branch calls
+> `start_multi(...)` and `return`s before any single-model flag is read.
+
+Both modes ultimately run through the same subprocess-isolated handler path
+(`HandlerProcessProxy`), so a single-model launch is internally converted to a
+one-entry multi-model config.
+
+---
+
+## Single-model mode (CLI flags)
+
+Launch:
+
+```bash
+mlx-openai-server launch --model-path mlx-community/SomeModel-4bit --model-type lm
+```
+
+### Server / process options
+
+| Flag | Default | Type | Notes |
+|------|---------|------|-------|
+| `--model-path` | — (required) | str | Required unless `--config` is used. HF repo or local path. |
+| `--model-type` | `lm` | choice | `lm`, `multimodal`, `image-generation`, `image-edit`, `embeddings`, `whisper` |
+| `--served-model-name` | `model_path` | str | Name exposed via `/v1/models` and accepted in the request `model` field. |
+| `--port` | `8000` | int | |
+| `--host` | `0.0.0.0` | str | |
+| `--queue-timeout` | `300` | int | **Request timeout in seconds.** Bounds the whole request (non-streaming) and is the per-chunk timeout (streaming). Also the queue-wait timeout. |
+| `--queue-size` | `100` | int | Max pending requests in the queue. |
+| `--log-file` | `logs/app.log` | str | Path to log file. |
+| `--no-log-file` | off | flag | Disable file logging (console only). |
+| `--log-level` | `INFO` | choice | `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (case-insensitive). |
+
+### LM / multimodal options
+
+| Flag | Default | Type | Applies to |
+|------|---------|------|-----------|
+| `--context-length` | model default | int | `lm`, `multimodal` |
+| `--enable-auto-tool-choice` | off | flag | `lm`, `multimodal` |
+| `--tool-call-parser` | auto-detect | choice | `lm`, `multimodal` |
+| `--reasoning-parser` | auto-detect | choice | `lm`, `multimodal` |
+| `--trust-remote-code` | off | flag | `lm`, `multimodal` |
+| `--chat-template-file` | none | str | `lm`, `multimodal` |
+| `--disable-auto-resize` | off | flag | `multimodal` (VLMs) |
+| `--debug` | off | flag | `lm`, `multimodal` |
+
+### Prompt KV cache (LM only)
+
+| Flag | Default | Type |
+|------|---------|------|
+| `--prompt-cache-size` | `10` | int |
+| `--max-bytes` | `2^63` | int (→ field `prompt_cache_max_bytes`) |
+| `--prompt-cache-dir` | temp dir | path |
+
+### KV cache quantization (`lm` / `multimodal` only)
+
+| Flag | Default | Type |
+|------|---------|------|
+| `--kv-bits` | none | int (e.g. `4`, `8`) |
+| `--kv-group-size` | `64` | int |
+| `--quantized-kv-start` | `0` | int |
+
+### Speculative decoding (LM only)
+
+| Flag | Default | Type |
+|------|---------|------|
+| `--draft-model-path` | none | str |
+| `--num-draft-tokens` | `2` | int |
+
+### Continuous-batching concurrency (`lm` / `multimodal`)
+
+These mirror mlx-lm's own server flags. Note the flag names differ from the
+underlying field names.
+
+| Flag | Field name | Default | Type |
+|------|-----------|---------|------|
+| `--decode-concurrency` | `batch_completion_size` | `32` | int |
+| `--prompt-concurrency` | `batch_prefill_size` | `8` | int |
+| `--prefill-step-size` | `batch_prefill_step_size` | `2048` | int |
+| `--disable-batching` | `disable_batching` | off | flag |
+
+### Image generation / edit options
+
+| Flag | Default | Type | Notes |
+|------|---------|------|-------|
+| `--quantize` | none | int | Flux models only. |
+| `--config-name` | type-dependent | choice | Required for image models. `image-generation` defaults to `flux-schnell`; `image-edit` to `flux-kontext-dev`. |
+| `--lora-paths` | none | comma-separated str | Multiple paths separated by commas. |
+| `--lora-scales` | none | comma-separated str | Multiple scales separated by commas. |
+
+### Default sampling parameters
+
+Used only when the API request omits the parameter. Flag names drop the
+`default_` prefix that the config field uses.
+
+| Flag | Field name | Type |
+|------|-----------|------|
+| `--max-tokens` | `default_max_tokens` | int |
+| `--temperature` | `default_temperature` | float |
+| `--top-p` | `default_top_p` | float |
+| `--top-k` | `default_top_k` | int |
+| `--min-p` | `default_min_p` | float |
+| `--repetition-penalty` | `default_repetition_penalty` | float |
+| `--presence-penalty` | `default_presence_penalty` | float |
+| `--xtc-probability` | `default_xtc_probability` | float |
+| `--xtc-threshold` | `default_xtc_threshold` | float |
+| `--seed` | `default_seed` | int |
+| `--repetition-context-size` | `default_repetition_context_size` | int |
+
+---
+
+## Multi-handler mode (YAML)
+
+Launch:
+
+```bash
+mlx-openai-server launch --config examples/config.yaml
+```
+
+The YAML has two top-level sections: an optional `server:` mapping and a
+required non-empty `models:` list. Each model entry is parsed directly into a
+`ModelEntryConfig`, so **the valid YAML keys are exactly the field names of
+`ModelEntryConfig`** (snake_case) — *not* the CLI flag spellings.
+
+### `server:` section
+
+All keys optional; defaults shown. (These replace the `--host`/`--port`/etc.
+CLI flags, which are ignored in this mode.)
+
+| Key | Default |
+|-----|---------|
+| `host` | `0.0.0.0` |
+| `port` | `8000` |
+| `log_level` | `INFO` |
+| `log_file` | none |
+| `no_log_file` | `false` |
+
+### `models:` list — per-entry keys
+
+`model_path` is required per entry; `served_model_name` must be unique across
+entries (defaults to `model_path`). Every key below is a `ModelEntryConfig`
+field.
+
+| YAML key | Default | Notes |
+|----------|---------|-------|
+| `model_path` | — (required) | HF repo or local path. |
+| `model_type` | `lm` | One of the six valid types. |
+| `served_model_name` | `model_path` | Must be unique across entries. |
+| `context_length` | model default | |
+| `queue_timeout` | `300` | Request timeout (seconds). |
+| `queue_size` | `100` | |
+| `quantize` | none | Image models. |
+| `config_name` | type-dependent | Image models. |
+| `lora_paths` | none | **YAML list** of strings (not comma string). |
+| `lora_scales` | none | **YAML list** of floats. |
+| `on_demand` | `false` | **YAML-only.** Lazy-load + idle-unload this model. |
+| `on_demand_idle_timeout` | `60` | **YAML-only.** Seconds idle before unloading. |
+| `disable_auto_resize` | `false` | VLMs. |
+| `enable_auto_tool_choice` | `false` | |
+| `tool_call_parser` | none | |
+| `reasoning_parser` | none | |
+| `message_converter` | auto | **YAML-only.** Lowercased; auto-resolved for lm/multimodal. |
+| `trust_remote_code` | `false` | |
+| `chat_template_file` | none | |
+| `debug` | `false` | |
+| `prompt_cache_size` | `10` | |
+| `prompt_cache_max_bytes` | `2^63` | (CLI: `--max-bytes`) |
+| `prompt_cache_dir` | none | |
+| `draft_model_path` | none | |
+| `num_draft_tokens` | `2` | |
+| `kv_bits` | none | |
+| `kv_group_size` | `64` | |
+| `quantized_kv_start` | `0` | |
+| `batch_completion_size` | `32` | (CLI: `--decode-concurrency`) |
+| `batch_prefill_size` | `8` | (CLI: `--prompt-concurrency`) |
+| `batch_prefill_step_size` | `2048` | (CLI: `--prefill-step-size`) |
+| `disable_batching` | `false` | |
+| `default_max_tokens` | none | (CLI: `--max-tokens`) |
+| `default_temperature` | none | (CLI: `--temperature`) |
+| `default_top_p` | none | (CLI: `--top-p`) |
+| `default_top_k` | none | (CLI: `--top-k`) |
+| `default_min_p` | none | (CLI: `--min-p`) |
+| `default_repetition_penalty` | none | (CLI: `--repetition-penalty`) |
+| `default_presence_penalty` | none | (CLI: `--presence-penalty`) |
+| `default_xtc_probability` | none | (CLI: `--xtc-probability`) |
+| `default_xtc_threshold` | none | (CLI: `--xtc-threshold`) |
+| `default_seed` | none | (CLI: `--seed`) |
+| `default_repetition_context_size` | none | (CLI: `--repetition-context-size`) |
+
+### Example
+
+```yaml
+server:
+  host: "0.0.0.0"
+  port: 8000
+  log_level: INFO
+
+models:
+  - model_path: mlx-community/MiniMax-M2.5-4bit
+    model_type: lm
+    served_model_name: Minimax-M2.5
+    queue_timeout: 600          # request timeout, in seconds
+    enable_auto_tool_choice: true
+    tool_call_parser: minimax_m2
+    reasoning_parser: minimax_m2
+
+  - model_path: black-forest-labs/FLUX.2-klein-4B
+    model_type: image-generation
+    config_name: flux2-klein-4b
+    quantize: 4
+    served_model_name: flux2-klein-4b
+    on_demand: true             # YAML-only: lazy load + idle unload
+    on_demand_idle_timeout: 120
+```
+
+---
+
+## What goes where — quick reference
+
+| Concern | Single-model | Multi-handler (`--config`) |
+|---------|--------------|----------------------------|
+| Server host/port/logging | `--host`, `--port`, `--log-level`, … | `server:` section in YAML |
+| Per-model settings | CLI flags | each entry under `models:` |
+| Request timeout | `--queue-timeout` | per-model `queue_timeout` |
+| Lazy / on-demand loading | *not available* | `on_demand`, `on_demand_idle_timeout` |
+| Custom message converter | *not available* | `message_converter` |
+| LoRA paths/scales | comma-separated strings | YAML lists |
+
+### Naming traps
+
+- **Flag ≠ field for several options.** `--max-bytes` → `prompt_cache_max_bytes`;
+  `--decode-concurrency` → `batch_completion_size`;
+  `--prompt-concurrency` → `batch_prefill_size`;
+  `--prefill-step-size` → `batch_prefill_step_size`.
+- **Sampling flags drop `default_`.** CLI `--temperature` is YAML
+  `default_temperature`, and so on for the whole sampling group.
+- **YAML-only keys** (no CLI equivalent): `on_demand`,
+  `on_demand_idle_timeout`, `message_converter`.
+- **Single-model-only**: there is no on-demand/idle-unload in single-model mode;
+  use a one-entry `--config` YAML if you need it.
+
+### Valid `model_type` values
+
+`lm`, `multimodal`, `image-generation`, `image-edit`, `embeddings`, `whisper`.

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,88 @@
+"""Tests for :func:`app.server.configure_logging`.
+
+These verify that the file sink is a faithful transcript of the console
+(same fields, including ``name:function:line``), that file logging can be
+disabled, and that rotation is opt-out for subprocess callers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+import re
+
+from loguru import logger
+import pytest
+
+from app.server import configure_logging
+
+# Matches one formatted record, e.g.:
+#   2026-06-02 12:00:00 | INFO     | tests.test_logging_config:test_x:42 | ✦ hello
+_RECORD_RE = re.compile(
+    r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| "
+    r"\w+\s+\| "
+    r"[\w.]+:\w+:\d+ \| "
+    r"✦ "
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging() -> Iterator[None]:
+    """Restore loguru to a clean state after each test."""
+    yield
+    logger.remove()
+
+
+def test_file_sink_shares_console_format(tmp_path: Path) -> None:
+    """The file sink records source location (name:function:line), not a stripped subset."""
+    log_path = tmp_path / "app.log"
+    configure_logging(log_file=str(log_path), log_level="INFO")
+
+    logger.info("hello-from-test")
+    logger.remove()  # flush + close the (enqueued) file sink
+
+    content = log_path.read_text(encoding="utf-8")
+    assert "hello-from-test" in content
+    # Source location must be present so the file matches the console.
+    assert _RECORD_RE.search(content), content
+    assert "test_file_sink_shares_console_format" in content
+    # File output must not contain raw color markup or ANSI escapes.
+    assert "<green>" not in content
+    assert "\x1b[" not in content
+
+
+def test_no_log_file_disables_file_sink(tmp_path: Path) -> None:
+    """``no_log_file=True`` must not create a log file."""
+    log_path = tmp_path / "app.log"
+    configure_logging(log_file=str(log_path), no_log_file=True)
+
+    logger.info("should-not-be-written")
+    logger.remove()
+
+    assert not log_path.exists()
+
+
+def test_log_level_filters_file_records(tmp_path: Path) -> None:
+    """Records below the configured level are not written to the file."""
+    log_path = tmp_path / "app.log"
+    configure_logging(log_file=str(log_path), log_level="WARNING")
+
+    logger.info("below-threshold")
+    logger.warning("at-threshold")
+    logger.remove()
+
+    content = log_path.read_text(encoding="utf-8")
+    assert "below-threshold" not in content
+    assert "at-threshold" in content
+
+
+def test_rotation_can_be_disabled_for_subprocesses(tmp_path: Path) -> None:
+    """``enable_rotation=False`` still writes, just without rotation/retention."""
+    log_path = tmp_path / "app.log"
+    # Should not raise and should still produce output for child processes.
+    configure_logging(log_file=str(log_path), enable_rotation=False)
+
+    logger.info("child-process-log")
+    logger.remove()
+
+    assert "child-process-log" in log_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Problem

`--log-file` / `log_file:` is misleading today: the log file is an incomplete, differently-formatted subset of the console output. Three distinct causes:

1. **Different format.** The file sink used `{time} | {level} | {message}`, dropping the `name:function:line` source location that the console format includes.
2. **Startup banner missing from file.** `print_startup_banner()` ran before `configure_logging()` added the file sink, so the entire config banner was console-only.
3. **Subprocess logs never reach the file (the big one).** Each model handler runs in its own `spawn`ed subprocess. loguru configuration does not survive `spawn`, and `_handler_worker` never reconfigured logging — so all handler/model/inference logs (model load, per-request errors, etc.) went to loguru's **default stderr handler**, were **never written to the file**, and **ignored `--log-level`**.

Net effect: the file contained only the parent/orchestration layer, in a stripped format, with no startup banner and none of the actual inference logs.

## Changes

- Share a single `_LOG_FORMAT` between the console and file sinks (loguru strips color markup on the non-colorized file sink), so the file now carries `name:function:line` too.
- Add an `enable_rotation` flag to `configure_logging`: only the parent rotates; children append to the same file with `enqueue=True`.
- Propagate `log_file` / `log_level` / `no_log_file` through `queue_config` and call `configure_logging()` in `_handler_worker`, so child logs reach the same file and honour the configured level.
- Configure logging **before** the startup banner so the banner is captured in the file.
- Add `docs/configuration.md`: a source-derived reference for the CLI flags and YAML schema, documenting the single-model vs `--config` mode split (single-model flags are ignored under `--config`).
- Add `tests/test_logging_config.py` covering format parity, `no_log_file`, level filtering, and rotation opt-out.

## Notes / trade-offs

- Parent and child processes append to the same log file. To avoid multiple writers racing on rotation, **only the parent rotates**; children append without rotation. When the parent rotates, in-flight children keep writing to the previous inode until they reopen — logs split rather than corrupt.
- `enqueue=True` on the file sink serializes writes within each process.

## Testing

- `pytest tests/test_logging_config.py` — 4 passing.
- `ruff check` / `ruff format` clean; all pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)