### PR TITLE
feat(whisper): add verbose_json response format with segments and language

### DIFF
--- a/app/handler/mlx_whisper.py
+++ b/app/handler/mlx_whisper.py
@@ -20,9 +20,43 @@ from ..schemas.openai import (
     TranscriptionResponseFormat,
     TranscriptionResponseStream,
     TranscriptionResponseStreamChoice,
+    TranscriptionSegment,
     TranscriptionUsageAudio,
 )
 from ..utils.errors import create_error_response
+
+
+def _coerce_segments(
+    raw_segments: object, time_offset: float = 0.0
+) -> list[TranscriptionSegment] | None:
+    """Convert ``mlx_whisper.transcribe``'s segment dicts to typed objects.
+
+    ``time_offset`` is added to each ``start``/``end`` value — used in the
+    streaming path where per-chunk segments are relative to the chunk start.
+
+    Returns ``None`` (not an empty list) when the input isn't a non-empty
+    list, so the response field stays ``None`` for non-verbose requests and
+    clients that don't understand the field see no change.
+    """
+    if not isinstance(raw_segments, list):
+        return None
+    out: list[TranscriptionSegment] = []
+    for i, seg in enumerate(raw_segments):
+        if not isinstance(seg, dict):
+            continue
+        try:
+            out.append(
+                TranscriptionSegment(
+                    id=int(seg.get("id", i)),
+                    start=float(seg.get("start", 0.0)) + time_offset,
+                    end=float(seg.get("end", 0.0)) + time_offset,
+                    text=str(seg.get("text", "")),
+                )
+            )
+        except (TypeError, ValueError):
+            # Malformed segment — skip rather than fail the whole response.
+            continue
+    return out or None
 
 
 class MLXWhisperHandler:
@@ -107,13 +141,26 @@ class MLXWhisperHandler:
                 audio_path=audio_path,
                 **request_data,
             )
+            duration_seconds = int(calculate_audio_duration(temp_file_path))
+            is_verbose = (
+                request.response_format == TranscriptionResponseFormat.VERBOSE_JSON
+            )
+            # mlx_whisper.transcribe() always returns {text, segments, language}.
+            # We surface them only when the caller asked for verbose_json so
+            # existing plain-JSON clients don't see unexpected fields.
             response_data = TranscriptionResponse(
                 text=response["text"],
                 usage=TranscriptionUsageAudio(
-                    type="duration", seconds=int(calculate_audio_duration(temp_file_path))
+                    type="duration", seconds=duration_seconds
                 ),
+                language=response.get("language") if is_verbose else None,
+                segments=_coerce_segments(response.get("segments")) if is_verbose else None,
+                duration=float(duration_seconds) if is_verbose else None,
             )
-            if request.response_format == TranscriptionResponseFormat.JSON:
+            if request.response_format in (
+                TranscriptionResponseFormat.JSON,
+                TranscriptionResponseFormat.VERBOSE_JSON,
+            ):
                 return response_data
             # dump to string for text response
             return json.dumps(response_data.model_dump())
@@ -133,13 +180,18 @@ class MLXWhisperHandler:
         Generate a transcription stream from prepared request data.
         Yields SSE-formatted chunks with timing information.
 
+        When ``response_format`` is ``VERBOSE_JSON`` each chunk also carries
+        ``segments`` (absolute timestamps) and ``language`` so clients can
+        build a line-by-line transcript without waiting for the final response.
+
         Args:
             request_data: Prepared request data with audio_path already saved
-            response_format: The response format (json or text)
+            response_format: The response format (json, text, or verbose_json)
         """
         request_id = f"transcription-{uuid.uuid4()}"
         created_time = int(time.time())
         temp_file_path = request_data.get("audio_path")
+        is_verbose = response_format == TranscriptionResponseFormat.VERBOSE_JSON
 
         try:
             # Set stream mode and submit to inference thread
@@ -151,12 +203,13 @@ class MLXWhisperHandler:
                 self.model,
                 audio_path=audio_path,
                 stream=True,
+                verbose=is_verbose,
                 **request_data,
             )
 
             # Stream each chunk (async — keeps event loop free)
             async for chunk in generator:
-                # Create streaming response
+                chunk_offset = float(chunk.get("chunk_start", 0.0))
                 stream_response = TranscriptionResponseStream(
                     id=request_id,
                     object="transcription.chunk",
@@ -164,7 +217,12 @@ class MLXWhisperHandler:
                     model=self.model_path,
                     choices=[
                         TranscriptionResponseStreamChoice(
-                            delta=Delta(content=chunk.get("text", "")), finish_reason=None
+                            delta=Delta(content=chunk.get("text", "")),
+                            finish_reason=None,
+                            segments=_coerce_segments(
+                                chunk.get("segments"), time_offset=chunk_offset
+                            ) if is_verbose else None,
+                            language=chunk.get("language") if is_verbose else None,
                         )
                     ],
                 )
@@ -179,7 +237,9 @@ class MLXWhisperHandler:
                 created=created_time,
                 model=self.model_path,
                 choices=[
-                    TranscriptionResponseStreamChoice(delta=Delta(content=""), finish_reason="stop")
+                    TranscriptionResponseStreamChoice(
+                        delta=Delta(content=""), finish_reason="stop"
+                    )
                 ],
             )
             yield f"data: {final_response.model_dump_json()}\n\n"
@@ -244,9 +304,15 @@ class MLXWhisperHandler:
             file = request.file
 
             file_path = await self._save_uploaded_file(file)
+            # Request verbose output from mlx_whisper when the caller asked
+            # for verbose_json — the model always computes segments/language
+            # internally; verbose=True just surfaces them in the return value.
+            is_verbose = (
+                request.response_format == TranscriptionResponseFormat.VERBOSE_JSON
+            )
             request_data = {
                 "audio_path": file_path,
-                "verbose": False,
+                "verbose": is_verbose,
             }
 
             # Add optional parameters if provided
@@ -289,7 +355,9 @@ class MLXWhisperHandler:
         ----------
         request_data : dict[str, Any]
             Dictionary containing ``audio_path`` and optional model
-            parameters (``temperature``, ``language``, etc.).
+            parameters (``temperature``, ``language``, ``verbose``, etc.).
+            When ``verbose`` is ``True`` the response includes ``language``,
+            ``segments``, and ``duration`` (i.e. ``verbose_json`` mode).
 
         Returns
         -------
@@ -297,19 +365,25 @@ class MLXWhisperHandler:
             The transcription result with text and usage info.
         """
         temp_file_path = request_data.get("audio_path")
+        is_verbose = request_data.pop("verbose", False)
         try:
             audio_path = request_data.pop("audio_path")
             response = await self.inference_worker.submit(
                 self.model,
                 audio_path=audio_path,
+                verbose=is_verbose,
                 **request_data,
             )
+            duration_seconds = int(calculate_audio_duration(temp_file_path))
             return TranscriptionResponse(
                 text=response["text"],
                 usage=TranscriptionUsageAudio(
                     type="duration",
-                    seconds=int(calculate_audio_duration(temp_file_path)),
+                    seconds=duration_seconds,
                 ),
+                language=response.get("language") if is_verbose else None,
+                segments=_coerce_segments(response.get("segments")) if is_verbose else None,
+                duration=float(duration_seconds) if is_verbose else None,
             )
         finally:
             if temp_file_path and os.path.exists(temp_file_path):
@@ -331,8 +405,10 @@ class MLXWhisperHandler:
         Parameters
         ----------
         request_data : dict[str, Any]
-            Dictionary containing ``audio_path`` and optional model
-            parameters.
+            Dictionary containing ``audio_path``, optional model parameters,
+            and an optional ``verbose`` boolean.  When ``verbose`` is ``True``
+            each streamed chunk includes ``segments`` and ``language``
+            (i.e. the caller requested ``response_format=verbose_json``).
 
         Yields
         ------
@@ -342,6 +418,7 @@ class MLXWhisperHandler:
         request_id = f"transcription-{uuid.uuid4()}"
         created_time = int(time.time())
         temp_file_path = request_data.get("audio_path")
+        is_verbose = request_data.pop("verbose", False)
 
         try:
             request_data["stream"] = True
@@ -352,10 +429,12 @@ class MLXWhisperHandler:
                 self.model,
                 audio_path=audio_path,
                 stream=True,
+                verbose=is_verbose,
                 **request_data,
             )
 
             async for chunk in generator:
+                chunk_offset = float(chunk.get("chunk_start", 0.0))
                 stream_response = TranscriptionResponseStream(
                     id=request_id,
                     object="transcription.chunk",
@@ -365,6 +444,10 @@ class MLXWhisperHandler:
                         TranscriptionResponseStreamChoice(
                             delta=Delta(content=chunk.get("text", "")),
                             finish_reason=None,
+                            segments=_coerce_segments(
+                                chunk.get("segments"), time_offset=chunk_offset
+                            ) if is_verbose else None,
+                            language=chunk.get("language") if is_verbose else None,
                         )
                     ],
                 )

--- a/app/handler/mlx_whisper.py
+++ b/app/handler/mlx_whisper.py
@@ -142,17 +142,13 @@ class MLXWhisperHandler:
                 **request_data,
             )
             duration_seconds = int(calculate_audio_duration(temp_file_path))
-            is_verbose = (
-                request.response_format == TranscriptionResponseFormat.VERBOSE_JSON
-            )
+            is_verbose = request.response_format == TranscriptionResponseFormat.VERBOSE_JSON
             # mlx_whisper.transcribe() always returns {text, segments, language}.
             # We surface them only when the caller asked for verbose_json so
             # existing plain-JSON clients don't see unexpected fields.
             response_data = TranscriptionResponse(
                 text=response["text"],
-                usage=TranscriptionUsageAudio(
-                    type="duration", seconds=duration_seconds
-                ),
+                usage=TranscriptionUsageAudio(type="duration", seconds=duration_seconds),
                 language=response.get("language") if is_verbose else None,
                 segments=_coerce_segments(response.get("segments")) if is_verbose else None,
                 duration=float(duration_seconds) if is_verbose else None,
@@ -221,7 +217,9 @@ class MLXWhisperHandler:
                             finish_reason=None,
                             segments=_coerce_segments(
                                 chunk.get("segments"), time_offset=chunk_offset
-                            ) if is_verbose else None,
+                            )
+                            if is_verbose
+                            else None,
                             language=chunk.get("language") if is_verbose else None,
                         )
                     ],
@@ -237,9 +235,7 @@ class MLXWhisperHandler:
                 created=created_time,
                 model=self.model_path,
                 choices=[
-                    TranscriptionResponseStreamChoice(
-                        delta=Delta(content=""), finish_reason="stop"
-                    )
+                    TranscriptionResponseStreamChoice(delta=Delta(content=""), finish_reason="stop")
                 ],
             )
             yield f"data: {final_response.model_dump_json()}\n\n"
@@ -307,9 +303,7 @@ class MLXWhisperHandler:
             # Request verbose output from mlx_whisper when the caller asked
             # for verbose_json — the model always computes segments/language
             # internally; verbose=True just surfaces them in the return value.
-            is_verbose = (
-                request.response_format == TranscriptionResponseFormat.VERBOSE_JSON
-            )
+            is_verbose = request.response_format == TranscriptionResponseFormat.VERBOSE_JSON
             request_data = {
                 "audio_path": file_path,
                 "verbose": is_verbose,
@@ -446,7 +440,9 @@ class MLXWhisperHandler:
                             finish_reason=None,
                             segments=_coerce_segments(
                                 chunk.get("segments"), time_offset=chunk_offset
-                            ) if is_verbose else None,
+                            )
+                            if is_verbose
+                            else None,
                             language=chunk.get("language") if is_verbose else None,
                         )
                     ],

--- a/app/schemas/openai.py
+++ b/app/schemas/openai.py
@@ -486,6 +486,7 @@ class TranscriptionResponseFormat(StrEnum):
 
     JSON = "json"
     TEXT = "text"
+    VERBOSE_JSON = "verbose_json"
 
 
 class ImageGenerationRequest(OpenAIBaseModel):
@@ -620,11 +621,38 @@ class TranscriptionUsageAudio(OpenAIBaseModel):
     seconds: int = Field(..., description="The duration of the audio in seconds")
 
 
+class TranscriptionSegment(OpenAIBaseModel):
+    """A single segment from Whisper output (``verbose_json`` only).
+
+    ``start`` and ``end`` are absolute timestamps in seconds.  The ``id``
+    matches the sequential segment index returned by ``mlx_whisper.transcribe``.
+    """
+
+    id: int = Field(..., description="Sequential segment id from the model.")
+    start: float = Field(..., description="Segment start time in seconds (absolute).")
+    end: float = Field(..., description="Segment end time in seconds (absolute).")
+    text: str = Field(..., description="Transcribed text for this segment.")
+
+
 class TranscriptionResponse(OpenAIBaseModel):
     """Represents a transcription response."""
 
     text: str = Field(..., description="The transcribed text.")
     usage: TranscriptionUsageAudio = Field(..., description="The usage of the transcription.")
+    # verbose_json extras — populated only when response_format=verbose_json.
+    # They remain None for plain JSON so existing clients don't see new fields.
+    language: str | None = Field(
+        None,
+        description="ISO 639-1 language code detected by Whisper (verbose_json only).",
+    )
+    segments: list[TranscriptionSegment] | None = Field(
+        None,
+        description="Per-segment timing and text from the model (verbose_json only).",
+    )
+    duration: float | None = Field(
+        None,
+        description="Total audio duration in seconds (verbose_json only).",
+    )
 
 
 class TranscriptionResponseStreamChoice(OpenAIBaseModel):
@@ -633,6 +661,12 @@ class TranscriptionResponseStreamChoice(OpenAIBaseModel):
     delta: Delta = Field(..., description="The delta for this streaming choice.")
     finish_reason: str | None = None
     stop_reason: int | str | None = None
+    # verbose_json extras per streamed chunk.  Segments carry absolute
+    # timestamps (chunk offset already applied).  Language is constant across
+    # the stream but echoed on every frame so clients can read it from the
+    # first chunk without buffering.
+    segments: list[TranscriptionSegment] | None = None
+    language: str | None = None
 
 
 class TranscriptionResponseStream(OpenAIBaseModel):


### PR DESCRIPTION
## Problem

`mlx_whisper.transcribe()` already computes per-segment timestamps and
auto-detects the source language, but the server handler was discarding
both fields before returning the response. This makes it impossible to
build line-by-line transcripts or know what language was spoken without
parsing the joined text.

## Changes

**`app/schemas/openai.py`**
- Add `VERBOSE_JSON = "verbose_json"` to `TranscriptionResponseFormat`
- Add `TranscriptionSegment` model (`id`, `start`, `end`, `text`)
- Extend `TranscriptionResponse` with optional `language` / `segments` / `duration`
  (all `None` on plain `json` — fully backward compatible)
- Extend `TranscriptionResponseStreamChoice` with optional `segments` / `language`

**`app/handler/mlx_whisper.py`**
- Add `_coerce_segments()` helper with `time_offset` for the streaming path
- Set `verbose=True` when `response_format=verbose_json` is requested
- Populate the new fields in all four code paths:
  `generate_transcription_response`, `transcribe_from_data` (IPC proxy),
  `generate_transcription_stream_from_data`, `transcribe_stream_from_data` (IPC proxy stream)

## Backward compatibility

All new fields are `Optional` with `None` defaults. Clients using
`response_format=json` or `response_format=text` receive identical
responses. Only callers explicitly requesting `verbose_json` see new data.

## Tested

mlx-community/whisper-large-v3-turbo on Apple M-series, end-to-end
through [TLDR](https://github.com/melnikaite/tldr-free) — a Chrome
extension that uses `verbose_json` to build a per-segment transcript tab
with binary-search line highlighting during playback.