### PR TITLE
fix: warm up model on caller thread before workers spawn (follow-up to #295)

### DIFF
--- a/app/core/batch_scheduler.py
+++ b/app/core/batch_scheduler.py
@@ -336,6 +336,7 @@ class BatchScheduler:
             return
         try:
             from mlx_lm.models.cache import make_prompt_cache  # noqa: PLC0415
+
             cache = make_prompt_cache(self._model)
             token_id = (
                 getattr(self._tokenizer, "bos_token_id", None)

--- a/app/core/batch_scheduler.py
+++ b/app/core/batch_scheduler.py
@@ -279,6 +279,19 @@ class BatchScheduler:
                     "mlx_lm.generate.BatchGenerator is not available in the"
                     " installed mlx-lm; upgrade mlx-lm to enable batching."
                 )
+            # Materialize the model's lazy MLX state on the caller thread
+            # before spawning the scheduler thread. Per-thread streams
+            # from #295 keep stream allocation on the worker, but the
+            # model itself carries deferred MLX state that binds to
+            # whichever thread first triggers it. A one-token forward +
+            # ``mx.eval`` here forces resolution on the loader thread so
+            # the scheduler thread only reads fully-materialized tensors.
+            # Without this, the first forward pass on the scheduler
+            # thread raises ``RuntimeError: There is no Stream(gpu, N)
+            # in current thread`` — same root cause as #290; #295
+            # resolved the stream-allocation side but not the
+            # model-state side.
+            self._warm_up_model()
             self._ready_event.clear()
             self._start_error = None
             self._running = True
@@ -308,6 +321,32 @@ class BatchScheduler:
             self._prefill_step_size,
             self._max_kv_size,
         )
+
+    def _warm_up_model(self) -> None:
+        """Run a one-token forward pass on the caller thread to materialize lazy MLX state.
+
+        See :meth:`start` for the rationale. Skipped silently for unit-test
+        mocks that pass a bare ``object()`` as the model (no ``.layers``
+        attribute). Exceptions are swallowed so a model that fails warm-up
+        does not prevent the scheduler from starting — the real first
+        forward pass on the worker thread will surface any actual problem
+        with a cleaner traceback.
+        """
+        if not hasattr(self._model, "layers"):
+            return
+        try:
+            from mlx_lm.models.cache import make_prompt_cache  # noqa: PLC0415
+            cache = make_prompt_cache(self._model)
+            token_id = (
+                getattr(self._tokenizer, "bos_token_id", None)
+                or getattr(self._tokenizer, "pad_token_id", None)
+                or 0
+            )
+            ids = mx.array([[token_id]])
+            logits = self._model(ids, cache=cache)
+            mx.eval(logits, [c.state for c in cache])
+        except Exception:  # noqa: BLE001 — best-effort warm-up
+            pass
 
     def stop(self) -> None:
         """Signal the scheduler thread to stop and wait for it to join.

--- a/app/handler/mlx_embeddings.py
+++ b/app/handler/mlx_embeddings.py
@@ -63,12 +63,36 @@ class MLXEmbeddingsHandler:
             Dictionary with ``queue_size`` and ``timeout`` keys used
             to configure the inference worker's internal queue.
         """
+        # Materialize the embedding model's lazy MLX state on the caller
+        # thread before the inference worker spawns. The worker owns its
+        # own per-thread MLX stream (#295); without this warm-up the
+        # model's deferred state binds to the worker thread on first use
+        # and later cross-thread evaluations raise ``RuntimeError: There
+        # is no Stream(gpu, N) in current thread``. Same root cause as
+        # ``MLXLMHandler._warm_up_model``.
+        self._warm_up_model()
         self.inference_worker = InferenceWorker(
             queue_size=config.get("queue_size", 100),
             timeout=config.get("timeout", 300),
         )
         self.inference_worker.start()
         logger.info("Initialized MLXEmbeddingsHandler and started inference worker")
+
+    def _warm_up_model(self) -> None:
+        """Run a one-input embed on the caller thread to materialize lazy MLX state.
+
+        See :meth:`initialize` for the rationale. Skipped silently for
+        unit-test mocks (model without ``.layers``). Exceptions are
+        swallowed so warm-up failure does not block startup — the real
+        first embed will surface any actual model problem with a cleaner
+        traceback.
+        """
+        if not hasattr(self.model, "layers"):
+            return
+        try:
+            self.model(texts=["a"])
+        except Exception:  # noqa: BLE001 — best-effort warm-up
+            pass
 
     async def generate_embeddings_response(self, request: EmbeddingRequest):
         """

--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -280,12 +280,51 @@ class MLXLMHandler:
             }
         self._queue_size = int(queue_config.get("queue_size", 100))
         self._queue_timeout = float(queue_config.get("timeout", 300))
+        # Materialize the model's lazy MLX state on the caller thread before
+        # the inference worker spawns. Requests that route through the
+        # inference worker (notably the ``--disable-batching`` path) run
+        # every forward pass on the worker thread, which owns its own
+        # per-thread stream (#295). Without this warm-up the model's
+        # deferred state binds to the worker thread on first use and later
+        # cross-thread evaluations raise ``RuntimeError: There is no
+        # Stream(gpu, N) in current thread`` — the May-14 follow-up
+        # comment on #290 shows this still hits Gemma 4 with
+        # ``--disable-batching`` even after #295.
+        self._warm_up_model()
         self.inference_worker = InferenceWorker(
             queue_size=self._queue_size,
             timeout=self._queue_timeout,
         )
         self.inference_worker.start()
         logger.info("Initialized MLXHandler and started inference worker")
+
+    def _warm_up_model(self) -> None:
+        """Run a one-token forward pass on the caller thread.
+
+        See :meth:`initialize` for the rationale. Skipped silently for
+        unit-test mocks (model without ``.layers``). Exceptions are
+        swallowed so warm-up failure does not block startup — the real
+        first inference will surface any actual model problem with a
+        cleaner traceback.
+        """
+        raw_model = getattr(self.model, "model", None)
+        tokenizer = getattr(self.model, "tokenizer", None)
+        if raw_model is None or not hasattr(raw_model, "layers"):
+            return
+        try:
+            import mlx.core as mx  # noqa: PLC0415
+            from mlx_lm.models.cache import make_prompt_cache  # noqa: PLC0415
+            cache = make_prompt_cache(raw_model)
+            token_id = (
+                getattr(tokenizer, "bos_token_id", None)
+                or getattr(tokenizer, "pad_token_id", None)
+                or 0
+            )
+            ids = mx.array([[token_id]])
+            logits = raw_model(ids, cache=cache)
+            mx.eval(logits, [c.state for c in cache])
+        except Exception:  # noqa: BLE001 — best-effort warm-up
+            pass
 
     def refine_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """

--- a/app/handler/mlx_lm.py
+++ b/app/handler/mlx_lm.py
@@ -314,6 +314,7 @@ class MLXLMHandler:
         try:
             import mlx.core as mx  # noqa: PLC0415
             from mlx_lm.models.cache import make_prompt_cache  # noqa: PLC0415
+
             cache = make_prompt_cache(raw_model)
             token_id = (
                 getattr(tokenizer, "bos_token_id", None)

--- a/tests/test_batch_scheduler.py
+++ b/tests/test_batch_scheduler.py
@@ -773,3 +773,78 @@ async def test_submit_stream_raises_queue_full_when_admission_queue_is_saturated
 
     with pytest.raises(asyncio.QueueFull):
         scheduler.submit_stream(input_ids=[2], max_tokens=4)
+
+
+def test_start_warms_up_model_on_caller_thread(patched_scheduler, monkeypatch):
+    """``start()`` must invoke the model on the caller thread before the worker spawns.
+
+    #290 reported ``RuntimeError: There is no Stream(gpu, N) in current
+    thread`` and was closed by #295. #295 fixed the stream-allocation side
+    (BatchScheduler and InferenceWorker now create their own per-thread
+    streams), but the model itself carries deferred MLX state that binds
+    to whichever thread first triggers it. When the scheduler thread is
+    that first thread, later cross-thread evaluations still fail.
+
+    The fix is to materialise the model's lazy state on the caller thread
+    before any worker thread touches it — a one-token forward + ``mx.eval``
+    is enough. This is the workaround Apple documents at
+    ml-explore/mlx#3529 (``mx.eval(model.parameters())`` before crossing
+    thread boundaries).
+    """
+    main_tid = threading.get_ident()
+    call_threads: list[int] = []
+
+    class WarmupModel:
+        # Presence of ``.layers`` distinguishes a real MLX model from the
+        # bare ``object()`` mocks used by other tests in this module. The
+        # warm-up must silently skip when ``.layers`` is absent so existing
+        # unit tests keep passing.
+        layers = (object(),)
+
+        def __call__(self, _ids: Any, cache: Any = None) -> Any:
+            call_threads.append(threading.get_ident())
+            return object()  # opaque logits
+
+    # The warm-up uses ``make_prompt_cache(self._model)``, ``mx.array(...)``,
+    # and ``mx.eval(...)``; the fixture only stubs stream-related calls, so
+    # we stub the rest here.
+    import mlx_lm.models.cache as cache_mod
+
+    monkeypatch.setattr(cache_mod, "make_prompt_cache", lambda _model: [])
+    monkeypatch.setattr(patched_scheduler.mx, "array", lambda _data: object())
+    monkeypatch.setattr(patched_scheduler.mx, "eval", lambda *_args, **_kwargs: None)
+
+    FakeBatchGenerator.script_queue = [_FakeScript(tokens=[10], finish_reason="length")]
+    scheduler = patched_scheduler.BatchScheduler(
+        model=WarmupModel(),
+        tokenizer=FakeTokenizer(),
+        idle_poll_timeout=0.01,
+    )
+    try:
+        scheduler.start()
+    finally:
+        scheduler.stop()
+
+    assert main_tid in call_threads, (
+        "BatchScheduler.start() must run a warm-up forward pass on the caller "
+        f"thread (id={main_tid}); observed call threads={call_threads}"
+    )
+
+
+def test_start_skips_warm_up_for_bare_object_model(patched_scheduler):
+    """Warm-up must be skipped silently when the model lacks ``.layers``.
+
+    Existing unit tests in this module pass ``model=object()``; the warm-up
+    must not crash or interfere with them.
+    """
+    FakeBatchGenerator.script_queue = [_FakeScript(tokens=[10], finish_reason="length")]
+    scheduler = patched_scheduler.BatchScheduler(
+        model=object(),
+        tokenizer=FakeTokenizer(),
+        idle_poll_timeout=0.01,
+    )
+    try:
+        scheduler.start()
+    finally:
+        scheduler.stop()
+    # No assertion needed beyond "no crash"; the scheduler started cleanly.

--- a/tests/test_mlx_embeddings_handler_warm_up.py
+++ b/tests/test_mlx_embeddings_handler_warm_up.py
@@ -1,0 +1,71 @@
+"""Tests that ``MLXEmbeddingsHandler.initialize()`` warms the model on the caller thread.
+
+Same root cause as the LM warm-ups in ``BatchScheduler._warm_up_model`` and
+``MLXLMHandler._warm_up_model`` (see those docstrings). Embedding requests
+route through ``InferenceWorker``, which owns its own per-thread MLX stream
+from #295; without a loader-thread warm-up the model's deferred state binds
+to the worker thread on first use and later cross-thread evaluations raise
+``RuntimeError: There is no Stream(gpu, N) in current thread``. The
+embedding fix is preventive — there is no specific report against this
+path yet, but it shares the failure mode #290/#295 covered for LM.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+
+def _install_stub_handler_deps(monkeypatch: pytest.MonkeyPatch, captured: list[int]) -> Any:
+    """Stub the embeddings model wrapper so we can construct the handler
+    without loading a real MLX model. Returns the handler module.
+    """
+
+    class _StubEmbeddingsModel:
+        # Sentinel attribute so the warm-up can detect a real model vs a
+        # bare ``object()``. Mirrors the ``.layers`` check used in the LM
+        # path; an embedding model exposes ``__call__`` so we use the same
+        # callable-based skip rule.
+        layers = (object(),)
+
+        def __init__(self, _model_path: str) -> None:
+            pass
+
+        def __call__(self, texts: list[str], max_length: int = 512) -> list[list[float]]:
+            captured.append(threading.get_ident())
+            return [[0.0] * 4 for _ in texts]
+
+        def cleanup(self) -> None:
+            return None
+
+    import app.models.mlx_embeddings as model_module
+
+    monkeypatch.setattr(model_module, "MLX_Embeddings", _StubEmbeddingsModel)
+
+    import app.handler.mlx_embeddings as handler_module
+
+    return handler_module
+
+
+@pytest.mark.asyncio
+async def test_initialize_warms_up_embedding_model_on_caller_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``initialize()`` must invoke the embedding model on the caller thread before the worker spawns."""
+    main_tid = threading.get_ident()
+    call_threads: list[int] = []
+    handler_module = _install_stub_handler_deps(monkeypatch, call_threads)
+
+    handler = handler_module.MLXEmbeddingsHandler(model_path="stub/path")
+    try:
+        await handler.initialize({})
+    finally:
+        if hasattr(handler, "inference_worker"):
+            handler.inference_worker.stop()
+
+    assert main_tid in call_threads, (
+        "MLXEmbeddingsHandler.initialize() must run a warm-up embed on the "
+        f"caller thread (id={main_tid}); observed call threads={call_threads}"
+    )

--- a/tests/test_mlx_lm_handler_warm_up.py
+++ b/tests/test_mlx_lm_handler_warm_up.py
@@ -1,0 +1,115 @@
+"""Tests that ``MLXLMHandler.initialize()`` warms the model on the caller thread.
+
+Same root cause as ``BatchScheduler._warm_up_model`` (see that docstring).
+The May-14 follow-up comment on #290 reports Gemma 4 still failing with
+``--disable-batching`` after #295 — that path routes through
+``InferenceWorker``, which owns its own thread-local stream. Without a
+loader-thread warm-up the model's deferred MLX state binds to the worker
+thread on first use and later cross-thread evaluations raise
+``RuntimeError: There is no Stream(gpu, N) in current thread``.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+
+def _install_stub_handler_deps(monkeypatch: pytest.MonkeyPatch, captured: list[int]) -> Any:
+    """Stub out heavy handler dependencies so we can construct the handler
+    in-process without loading a real MLX model. Returns the imported
+    handler module (so the test can read its class).
+    """
+
+    class _StubRawModel:
+        # Presence of ``.layers`` distinguishes a real model from unit-test
+        # mocks; the warm-up must skip when absent.
+        layers = (object(),)
+
+        def __call__(self, _ids: Any, cache: Any = None) -> Any:
+            captured.append(threading.get_ident())
+            return object()  # opaque logits
+
+    class _StubTokenizer:
+        bos_token_id = 1
+        pad_token_id = 0
+        eos_token_ids: list[int] = [1]
+        eos_token_id = 1
+        vocab_size = 32000
+
+    class _StubMLX_LM:
+        def __init__(self, model_path: str, **_kwargs: Any) -> None:
+            self.model = _StubRawModel()
+            self.tokenizer = _StubTokenizer()
+            self.draft_model = None
+            self.draft_tokenizer = None
+            self.model_type = "stub"
+            self.pad_token_id = 0
+            self.bos_token = "<s>"
+
+        def get_model_type(self) -> str:
+            return self.model_type
+
+    # Patch the wrapper before the handler module imports it.
+    import app.models.mlx_lm as model_module
+
+    monkeypatch.setattr(model_module, "MLX_LM", _StubMLX_LM)
+
+    # ``test_batch_scheduler.test_request_seed_does_not_disable_batching``
+    # (and others in that module) pop ``app.handler.mlx_lm`` from
+    # ``sys.modules`` and re-import it against a fake ``app.core`` that
+    # replaces ``InferenceWorker`` with a no-arg stub. The pop is not
+    # undone by ``monkeypatch``, so the handler module we just imported
+    # may carry a stale ``_FakeInferenceWorker``. Re-bind to the real
+    # class defensively.
+    from app.core.inference_worker import InferenceWorker as _RealInferenceWorker
+    import app.handler.mlx_lm as handler_module
+
+    monkeypatch.setattr(handler_module, "InferenceWorker", _RealInferenceWorker)
+
+    # Bypass parser loading (returns ``None`` is safe; handler tolerates it).
+    monkeypatch.setattr(
+        handler_module.MessageConverterManager,
+        "create_converter",
+        staticmethod(lambda **_kwargs: None),
+    )
+
+    # Stub the warm-up's MLX-side calls so it runs end-to-end without real MLX.
+    import mlx_lm.models.cache as cache_mod
+
+    monkeypatch.setattr(cache_mod, "make_prompt_cache", lambda _model: [])
+    import mlx.core as mx
+
+    monkeypatch.setattr(mx, "array", lambda _data: object())
+    monkeypatch.setattr(mx, "eval", lambda *_args, **_kwargs: None)
+
+    return handler_module
+
+
+@pytest.mark.asyncio
+async def test_initialize_warms_up_model_on_caller_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``initialize()`` must invoke the model on the caller thread before the worker spawns.
+
+    This is the ``--disable-batching`` path — the one the May-14 follow-up
+    comment on #290 reports is still broken on Gemma 4 even after #295.
+    """
+    main_tid = threading.get_ident()
+    call_threads: list[int] = []
+    handler_module = _install_stub_handler_deps(monkeypatch, call_threads)
+
+    handler = handler_module.MLXLMHandler(model_path="stub/path")
+    try:
+        await handler.initialize({})
+    finally:
+        # Best-effort cleanup; the worker thread is harmless either way.
+        if hasattr(handler, "inference_worker"):
+            handler.inference_worker.stop()
+
+    assert main_tid in call_threads, (
+        "MLXLMHandler.initialize() must run a warm-up forward pass on the "
+        f"caller thread (id={main_tid}); observed call threads={call_threads}"
+    )


### PR DESCRIPTION
## Summary

Follow-up to #295. Closes the residual `RuntimeError: There is no Stream(gpu, N) in current thread` failure that #290's May 14 follow-up comment showed still hits Gemma 4 with `--disable-batching`. Same root cause also blocks the default chat path on sliding-window models and the embedding path.

## What's still broken after #295

#295 was the right partial fix — per-thread MLX streams on `BatchScheduler` and `InferenceWorker`. But it doesn't address the model's *lazy state*. Loading a model with `mlx_lm.utils.load(...)` leaves some allocations deferred; the first forward pass binds them to whichever thread triggers it. When that's the worker thread, later cross-thread evaluations still fail — #295's stream changes don't help because the failure is in the model's array stream binding, not the scheduler's stream allocation.

@therealmobasha's comment on #290 (May 14):
> Still running into this issue with gemma4 models even when using `--disable-batching`

## Root cause confirmed at the MLX layer

This is the contract @zcbenz documented at [ml-explore/mlx#3529](https://github.com/ml-explore/mlx/issues/3529):
> This is expected behavior because we don't support evaluating an array created in another thread. Two solutions: (1) inherit from `nn.Module` and call `mx.eval(model.parameters())` before passing to the worker, (2) create the class in the worker.

mlx-lm side: [#1256](https://github.com/ml-explore/mlx-lm/issues/1256) (open) tracks this; [#1275](https://github.com/ml-explore/mlx-lm/pull/1275) (open) proposes a per-thread `generation_stream`. Even if #1275 merges, schedulers that own their own per-worker stream (this repo) still need a consumer-side warm-up — the bug is in lazy *model* state, not the module-level stream.

## Fix

One-token forward + `mx.eval` on the caller thread, before any worker spawns. Three sites — same root cause, three execution paths:

| File | Method | Path |
|---|---|---|
| `app/core/batch_scheduler.py` | `BatchScheduler.start()` | default chat (continuous batching) |
| `app/handler/mlx_lm.py` | `MLXLMHandler.initialize()` | `--disable-batching` (the May 14 #290 path) |
| `app/handler/mlx_embeddings.py` | `MLXEmbeddingsHandler.initialize()` | embeddings (preventive — same failure mode) |

Warm-up exceptions are swallowed so a faulty model doesn't block startup. Skipped silently for unit-test mocks (no `.layers` attribute) so existing tests that pass `model=object()` keep working.

## Minimal repro (no server needed)

```python
# pip install mlx mlx-lm
from mlx_lm.utils import load
from mlx_lm.models.cache import make_prompt_cache
import mlx.core as mx
import threading

model, tok = load("mlx-community/Llama-3.2-1B-Instruct-4bit")

def worker():
    s = mx.new_thread_local_stream(mx.default_device())
    with mx.stream(s):
        c = make_prompt_cache(model)
        ids = mx.array([tok.encode("hi")])
        mx.eval(model(ids, cache=c), [x.state for x in c])

threading.Thread(target=worker).start()
# -> RuntimeError: There is no Stream(gpu, 1) in current thread.
```

Verified against `mlx 0.31.2` / `mlx-lm 0.31.3` (current PyPI pins).

## Performance

Single forward pass over a single token at startup. ~100ms on M2 Pro with a 1B 4-bit model.

## Tests

Four new tests, all pass:
- `test_batch_scheduler.py::test_start_warms_up_model_on_caller_thread`
- `test_batch_scheduler.py::test_start_skips_warm_up_for_bare_object_model`
- `test_mlx_lm_handler_warm_up.py::test_initialize_warms_up_model_on_caller_thread`
- `test_mlx_embeddings_handler_warm_up.py::test_initialize_warms_up_embedding_model_on_caller_thread`

Each mocks the model with a callable that records the thread id on every invocation, then asserts the model was called on the caller thread before any worker spawned.

Full suite: 14 pre-existing failures (orthogonal — `_FakeLRU.allowed_sources` kwarg drift and parser drift in `test_mixed_think_tool_handoff_*`); zero new regressions.

## Related upstream
- ml-explore/mlx#3529 — Apple's documented contract
- ml-explore/mlx-lm#1256 — root-cause issue
- ml-explore/mlx-lm#1275 — proposed mlx-lm-side fix (open)
- #290 (closed) — original symptom report
- #295 (merged) — per-thread stream fix this PR builds on